### PR TITLE
ci: Generate map & run calcprogress

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
           | bsdtar -xvf- -C tools --exclude Wii
         mv tools/GC tools/mwcc_compiler
     - name: make
-      run: UPDATE_README=0 make -j
+      run: MAPGENFLAG=1 UPDATE_README=0 make -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ ifeq ($(WINDOWS),1)
   CPP     := $(DEVKITPPC)/bin/powerpc-eabi-cpp.exe -P
 else
   WINE ?= wine
+  # Disable wine debug output for cleanliness
+  export WINEDEBUG ?= -all
+  # Default devkitPPC path
+  DEVKITPPC ?= /opt/devkitpro/devkitPPC
   AS      := $(DEVKITPPC)/bin/powerpc-eabi-as
   CPP     := $(DEVKITPPC)/bin/powerpc-eabi-cpp -P
 endif
@@ -176,7 +180,7 @@ $(DOL): $(ELF) | tools
 	$(QUIET) $(ELF2DOL) $< $@
 	$(QUIET) $(SHA1SUM) -c sha1/$(NAME).$(VERSION).sha1
 ifneq ($(findstring -map,$(LDFLAGS)),)
-	$(QUIET) $(PYTHON) tools/calcprogress.py $@
+	$(QUIET) $(PYTHON) tools/calcprogress.py $(DOL) $(MAP)
 endif
 ifeq ($(UPDATE_README),1)
 	$(WINE) $(READMEGEN)

--- a/tools/calcprogress.py
+++ b/tools/calcprogress.py
@@ -31,9 +31,6 @@ import math
 #                                             #
 ###############################################
 
-DOL_PATH = "baserom.dol"
-MAP_PATH = "build/pikmin2.usa/pikmin2UP.MAP"
-
 MEM1_HI = 0x81200000
 MEM1_LO = 0x80004000
 
@@ -84,7 +81,7 @@ dataItem = "treasures"  # data flavor item
 
 if __name__ == "__main__":
     # Sum up DOL section sizes
-    dol_handle = open(DOL_PATH, "rb")
+    dol_handle = open(sys.argv[1], "rb")
 
     # Seek to virtual addresses
     dol_handle.seek(0x48)
@@ -126,7 +123,7 @@ if __name__ == "__main__":
         dol_code_size += i
 
     # Open map file
-    mapfile = open(MAP_PATH, "r")
+    mapfile = open(sys.argv[2], "r")
     symbols = mapfile.readlines()
 
     decomp_code_size = 0


### PR DESCRIPTION
Modifies calcprogress.py to use the passed in dol & map files from Makefile.

Additional changes: use default devkitPPC path by default & disables Wine debug output which clutters up the build.