### PR TITLE
Add dep tracking & use WiBo in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         cmake -B build
         cmake --build build
     - name: Build
-      run: make -j$(nproc) WINE=./tools/WiBo/build/wibo MAPGENFLAG=1
+      run: make -j$(nproc) WINE=./tools/WiBo/build/wibo MAPGENFLAG=1 UPDATE_README=0
     - name: Upload map
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,30 @@ jobs:
     env:
       WINEPREFIX: ${{github.workspace}}/.wine
     steps:
-    - name: Install devkitPro
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Checkout WiBo
+      uses: actions/checkout@v3
+      with:
+        repository: decompals/WiBo
+        path: tools/WiBo
+    - name: Install dependencies
       run: |
         sudo dpkg --add-architecture i386
         sudo apt-get update
-        sudo apt-get -y install build-essential wine32
-        sudo chown $(whoami) "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@v3
-    - name: Download compilers
-      run: |
+        sudo apt-get -y install build-essential gcc-multilib g++-multilib libc6:i386
         curl -L https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip \
           | bsdtar -xvf- -C tools --exclude Wii
-        mv tools/GC tools/mwcc_compiler
-    - name: make
-      run: MAPGENFLAG=1 UPDATE_README=0 make -j$(nproc)
+        mv tools/GC/* tools/mwcc_compiler/
+    - name: Build WiBo
+      working-directory: tools/WiBo
+      run: |
+        cmake -B build
+        cmake --build build
+    - name: Build
+      run: make -j$(nproc) WINE=./tools/WiBo/build/wibo MAPGENFLAG=1
+    - name: Upload map
+      uses: actions/upload-artifact@v2
+      with:
+        name: pikmin2UP.MAP
+        path: build/*/pikmin2UP.MAP

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@
 include/*.s
 
 build/
-tools/mwcc_compiler/
+tools/mwcc_compiler/*    
+!tools/mwcc_compiler/.gitkeep
 decomp/
 errors.txt
 output.asm

--- a/tools/transform-dep.py
+++ b/tools/transform-dep.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import argparse
+import os
+
+wineprefix = os.path.join(os.environ['HOME'], '.wine')
+if 'WINEPREFIX' in os.environ:
+  wineprefix = os.environ['WINEPREFIX']
+winedevices = os.path.join(wineprefix, 'dosdevices')
+
+def import_d_file(in_file) -> str:
+    out_text = ''
+
+    with open(in_file) as file:
+      for idx, line in enumerate(file):
+        if idx == 0:
+          if line.endswith(' \\\n'):
+            out_text += line[:-3].replace('\\', '/') + " \\\n"
+          else:
+            out_text += line.replace('\\', '/')
+        else:
+          suffix = ''
+          if line.endswith(' \\\n'):
+            suffix = ' \\'
+            path = line.lstrip()[:-3]
+          else:
+            path = line.strip()
+          # lowercase drive letter
+          path = path[0].lower() + path[1:]
+          # use $WINEPREFIX/dosdevices to resolve path
+          path = os.path.realpath(os.path.join(winedevices, path.replace('\\', '/')))
+          out_text += "\t" + path + suffix + "\n"
+
+    return out_text
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="""Transform a .d file from Wine paths to normal paths"""
+    )
+    parser.add_argument(
+        "d_file",
+        help="""Dependency file in""",
+    )
+    parser.add_argument(
+        "d_file_out",
+        help="""Dependency file out""",
+    )
+    args = parser.parse_args()
+
+    output = import_d_file(args.d_file)
+
+    with open(args.d_file_out, "w", encoding="UTF-8") as f:
+        f.write(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Generates dependency info from C/C++ files, allowing make to track what objects need to be rebuilt when a header changes.

[WiBo](https://github.com/decompals/WiBo) is a simple wrapper for 32-bit CLI Windows executables. It's faster overall and more stable in CI. If wibo is detected on path, configure it instead of wine automatically.