### PR TITLE
once-over of vsTekiMgr.cpp

### DIFF
--- a/include/Game/VsGame/VsGame.h
+++ b/include/Game/VsGame/VsGame.h
@@ -31,12 +31,16 @@ struct TekiNode : public CNode {
 	int m_nodeID;                   // _20
 };
 
-struct TekiMgr {
+class TekiMgr {
 	TekiMgr();
 
 	void entry(EnemyTypeID::EEnemyTypeID, int);
+	TekiNode* getNode(int); // unused; inlined into birth
+	bool birthable(int);    // unused
 	EnemyBase* birth(int, Vector3f&, bool);
+	EnemyTypeID::EEnemyTypeID getID(int); // unused
 
+	// these elements were likely private
 	TekiNode m_node; // _00
 	int m_nodeCount; // _24
 };

--- a/src/plugProjectKandoU/vsTekiMgr.cpp
+++ b/src/plugProjectKandoU/vsTekiMgr.cpp
@@ -14,13 +14,6 @@ TekiMgr::TekiMgr() { m_nodeCount = 0; }
 
 /*
  * --INFO--
- * Address:	80235334
- * Size:	000060
- * TekiNode's destructor (weak, lives in "Game/VsGame/VsGame.h")
- */
-
-/*
- * --INFO--
  * Address:	80235394
  * Size:	0000A0
  */

--- a/src/plugProjectKandoU/vsTekiMgr.cpp
+++ b/src/plugProjectKandoU/vsTekiMgr.cpp
@@ -14,6 +14,13 @@ TekiMgr::TekiMgr() { m_nodeCount = 0; }
 
 /*
  * --INFO--
+ * Address:	80235334
+ * Size:	000060
+ * TekiNode's destructor (weak, lives in "Game/VsGame/VsGame.h")
+ */
+
+/*
+ * --INFO--
  * Address:	80235394
  * Size:	0000A0
  */
@@ -28,9 +35,35 @@ void TekiMgr::entry(EnemyTypeID::EEnemyTypeID id, int a2)
 	generalEnemyMgr->addEnemyNum(id, a2, nullptr);
 }
 
+/*
+ * --INFO--
+ * Address:	........
+ * Size:	000020
+ */
+TekiNode* TekiMgr::getNode(int idx) { return static_cast<TekiNode*>(m_node.getChildAt(idx)); }
+
+/*
+ * --INFO--
+ * Address:	........
+ * Size:	00002C
+ * Speculation: possibly inlined into TekiMgr::birth
+ * Unknown return type
+ */
+/*
+bool TekiMgr::birthable(int)
+{
+    // UNUSED FUNCTION
+}
+*/
+
+/*
+ * --INFO--
+ * Address:	80235434
+ * Size:	0000D8
+ */
 EnemyBase* TekiMgr::birth(int idx, Vector3f& position, bool check)
 {
-	if (TekiNode* node = static_cast<TekiNode*>(m_node.getChildAt(idx))) {
+	if (TekiNode* node = getNode(idx)) {
 		EnemyBirthArg birthArg;
 		birthArg.m_faceDir  = TAU * randFloat();
 		birthArg.m_position = position;
@@ -45,5 +78,19 @@ EnemyBase* TekiMgr::birth(int idx, Vector3f& position, bool check)
 	}
 	return nullptr;
 }
+
+/*
+ * --INFO--
+ * Address:	........
+ * Size:	000034
+ * Unknown return type. Likely int or EnemyTypeID::EEnemyTypeID
+ */
+/*
+EnemyTypeID::EEnemyTypeID TekiMgr::getID(int)
+{
+    // UNUSED FUNCTION
+}
+*/
+
 } // namespace VsGame
 } // namespace Game

--- a/src/plugProjectKandoU/vsTekiMgr.cpp
+++ b/src/plugProjectKandoU/vsTekiMgr.cpp
@@ -56,7 +56,8 @@ bool TekiMgr::birthable(int)
  */
 EnemyBase* TekiMgr::birth(int idx, Vector3f& position, bool check)
 {
-	if (TekiNode* node = getNode(idx)) {
+	TekiNode* node = getNode(idx);
+	if (node != nullptr) {
 		EnemyBirthArg birthArg;
 		birthArg.m_faceDir  = TAU * randFloat();
 		birthArg.m_position = position;


### PR DESCRIPTION
restored a stripped function as an inline, updated scope of class members