### PR TITLE
Add VS Code workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ errors.txt
 output.asm
 Debug/
 .vs/
+.vscode/*.log
 
 ctx.c
 out-ok.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 *.dat
 *.exe
 *.dll

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -7,7 +7,9 @@
             ],
             "cStandard": "c99",
             "cppStandard": "c++98",
-            "intelliSenseMode": "linux-clang-x86"
+            "intelliSenseMode": "linux-clang-x86",
+            "compilerPath": "",
+            "configurationProvider": "ms-vscode.makefile-tools"
         }
     ],
     "version": 4

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,14 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/include"
+            ],
+            "cStandard": "c99",
+            "cppStandard": "c++98",
+            "intelliSenseMode": "linux-clang-x86"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-vscode.cpptools",
+    "xaver.clang-format"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "[c]": {
+    "files.encoding": "shiftjis",
+    "editor.defaultFormatter": "xaver.clang-format"
+  },
+  "[cpp]": {
+    "files.encoding": "shiftjis",
+    "editor.defaultFormatter": "xaver.clang-format"
+  },
+  "editor.tabSize": 2,
+  "files.associations": {
+    "source_location": "cpp"
+  }
+}


### PR DESCRIPTION
This configures VS Code to use Shift-JIS encoding for source files by default, as well as clang-format as the formatter.