### PR TITLE
Remove USA Demo 1 Specific Padding from VsGameSection.h

### DIFF
--- a/include/Game/VsGameSection.h
+++ b/include/Game/VsGameSection.h
@@ -71,10 +71,6 @@ struct VsGameSection : public BaseGameSection {
 	void useCard();
 
 	u8 _174[0xA0]; // _174
-// not sure where this goes, but it goes after m_texData1 and before m_container1.
-#if BUILDTARGET == USADEMO1
-	u8 _DemoPadding3[0x4];
-#endif
 	// probably red and blue 2pbattle onyons
 	PikiContainer m_container1; // _214
 	PikiContainer m_container2; // _21C


### PR DESCRIPTION
Building a matching USA Demo 1 dol was failing on this. It appears that whatever this data is supposed to be, its inherited from the BaseGameSection object.