### PR TITLE
Tweak to build instructions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ This repository builds the following DOLs:
 
 1. Clone the repo using `git clone https://github.com/projectPiki/pikmin2/`
 
-2. Download [GC_WII_COMPILERS.zip](https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip) and extract the contents of the GC folder to `tools/mwcc_compiler/` - you'll have to make this folder yourself. For example, your directory structure should look like `pikmin2/tools/mwcc_compiler/2.6/` (along with the other versions).
+2. Download [GC_WII_COMPILERS.zip](https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip) and extract the contents of the GC folder to `tools/mwcc_compiler/`. For example, your directory structure should look like `pikmin2/tools/mwcc_compiler/2.6/` (along with the other versions).
 
 3. Run `make -j` in a command prompt or terminal.
 	- -j Allows `make` to use multiple threads, speeding up the process.


### PR DESCRIPTION
This repo already contains an empty /tools/mwcc_compiler/ directory, so I just removed the part of the build instructions saying you need to add it yourself.

Alternatively, if the build instructions _are_ correct.. there's a directory that shouldn't be there