### PR TITLE
Automate `devkitPPC` download, remove `devkitpro` dependency

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -439,7 +439,7 @@ LIBS = [
             ["Dolphin/TRK_MINNOW_DOLPHIN/targimpl", False],
             [
                 "Dolphin/TRK_MINNOW_DOLPHIN/targsupp",
-                True, 
+                True,
                 {"cflags": "$cflags_base -inline deferred -func_align 32"},
             ],
             ["Dolphin/TRK_MINNOW_DOLPHIN/mpc_7xx_603e", True],
@@ -1471,10 +1471,10 @@ LIBS = [
             ["plugProjectEbisawaU/efxEnemyGeneral", True],
             ["plugProjectEbisawaU/ebi3DGraph", True],
             ["plugProjectEbisawaU/ebiGeometry", True],
-            ["plugProjectEbisawaU/ebi2DGraph", False], 
+            ["plugProjectEbisawaU/ebi2DGraph", False],
             ["plugProjectEbisawaU/ebiScreenOption", True],
             ["plugProjectEbisawaU/ebiScreenProgre", True],
-            ["plugProjectEbisawaU/ebiOptionMgr", True], 
+            ["plugProjectEbisawaU/ebiOptionMgr", True],
             ["plugProjectEbisawaU/ebi2DCallBack", False],
             ["plugProjectEbisawaU/ebiCardMgr", True],
             ["plugProjectEbisawaU/ebiScreenFramework", True],
@@ -1770,10 +1770,11 @@ if __name__ == "__main__":
         dkp_path = args.devkitppc
     elif "DEVKITPPC" in os.environ:
         dkp_path = Path(os.environ["DEVKITPPC"])
-    elif os.name == "nt":
-        dkp_path = Path("C:\devkitPro\devkitPPC")
     else:
-        dkp_path = Path("/opt/devkitpro/devkitPPC")
+        dkp_path = Path("tools/devkitPPC")
+        if not dkp_path.exists():
+            import tools.download_ppc
+            tools.download_ppc.main()
 
     cflags_base = f"-proc gekko -nodefaults -Cpp_exceptions off -RTTI off -fp hard -fp_contract on -O4,p -maxerrors 1 -enum int -inline auto -str reuse,readonly -nosyspath -use_lmw_stmw on -sdata 8 -sdata2 8 -DVERNUM={version_num} -i include -i include/stl"
     if args.debug:

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -5,3 +5,4 @@ elf2dol
 !UpdateReadme.exe
 !UpdateReadme.runtimeconfig.json
 dtk
+devkitPPC

--- a/tools/download_ppc.py
+++ b/tools/download_ppc.py
@@ -1,0 +1,70 @@
+import urllib.request
+import os
+import stat
+import platform
+import shutil
+import tempfile
+import tarfile
+from typing import Optional
+
+
+try:
+    import zstandard
+except:
+    print("zstandard module not found, downloading...")
+    import subprocess
+    import sys
+
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "zstandard"], stdout=subprocess.DEVNULL)
+    import zstandard
+
+    print("zstandard module successfully downloaded!")
+
+# TODO: Less hardcoded elements
+REPO = "https://wii.leseratte10.de/devkitPro/devkitPPC/r44%20%282023-08-07%29/"
+
+
+def main() -> None:
+    output = f"{os.path.dirname(__file__)}/devkitPPC"
+
+    uname = platform.uname()
+    system = uname.system.lower()
+    arch = uname.machine.lower()
+    if system == "darwin":
+        system = "osx"
+    if arch == "amd64":
+        arch = "x86_64"
+    if arch == "x86_32" and system == "windows":
+        system = "win32"
+        arch = "1686"
+    if arch in ["armv8", "arm64v8", "aarch64"]:
+        arch = "aarch64"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_zst = f"{tmp}/tmp.tar.zst"
+        tmp_tar = f"{tmp}/tmp.tar"
+        tmp_dir = f"{tmp}/tmp"
+        tmp_ppc = f"{tmp_dir}/opt/devkitpro/devkitPPC"
+
+        request = urllib.request.Request(
+            url=f"{REPO}/devkitPPC-r44.2-2-{system}_{arch}.pkg.tar.zst",
+            headers={"User-Agent": "Mozilla/5.0"},
+        )
+
+        with urllib.request.urlopen(request) as src, open(tmp_zst, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+
+        with open(tmp_zst, "rb") as src, open(tmp_tar, "wb") as dst:
+            zstandard.ZstdDecompressor().copy_stream(src, dst)
+
+        with tarfile.open(tmp_tar) as src:
+            src.extractall(tmp_dir)
+
+        shutil.move(tmp_ppc, output)
+
+    st = os.stat(output)
+    os.chmod(output, st.st_mode | stat.S_IEXEC)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change means the Ninja buildsystem no longer needs `devkitpro` as a prerequisite. `download_ppc.py` automatically called when using `configure.py` if the folder hasn't been generated before, otherwise the process is skipped. It's still possible to override the devkitPPC location with environment variables and arguments, and doing so will skip the creation process, but this will mean any future contributors won't have to download the entire bundled system separately. Make still requires `devkitpro` because I have no goddamn clue how those files are setup, but Ninja is better anyway so idc ☕