### PR TITLE
Add `requirements.txt` for zstandard module

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-﻿Language: Cpp
+Language: Cpp
 
 BasedOnStyle: WebKit
 ColumnLimit: 140

--- a/README.MD
+++ b/README.MD
@@ -22,26 +22,26 @@ This repository builds the following DOLs:
 ## Building
 
 ### Required Tools
-* python
+[Python 3.8+](https://www.python.org/downloads/)
 
 ### Instructions
 
 1. Clone the repo using `git clone https://github.com/projectPiki/pikmin2/`
 
-2. Download [GC_WII_COMPILERS.zip](https://files.decomp.dev/compilers_20230715.zip) and extract the contents of the GC folder to `tools/mwcc_compiler/`. For example, your directory structure should look like `pikmin2/tools/mwcc_compiler/2.6/` (along with the other versions).
+2. Install required python modules with `pip install -r requirements.txt`.
 
-3. Run `configure.py`.
-	- Automatically downloads any other necessary files for the project.
-	- If using `ninja`, will prepare all relevant scripts.
+3. Download [GC_WII_COMPILERS.zip](https://files.decomp.dev/compilers_20230715.zip) and extract the contents of the GC folder to `tools/mwcc_compiler/`. For example, your directory structure should look like `pikmin2/tools/mwcc_compiler/2.6/` (along with the other versions).
 
-4. Run `make -j` or `ninja` in a command prompt or terminal.
-	- -j Allows `make` to use multiple threads, speeding up the process.
+4. Run `python configure.py` to automatically download/build any other necessary files for the project.
+
+5. Run `ninja` (recommended) or `make -j` in a command prompt or terminal.
+	- `-j` Allows `make` to use multiple threads, speeding up the process.
 	- `ninja` already implicitly uses the max amount of cores available, only use `-j` to *decrease* the thread count.
 	- If just `-j` gives errors on your setup, try specifying a set number of threads, e.g. `make -j 4`.
 
 * OPTIONAL STEPS:
 	- Obtain a clean DOL of Pikmin 2 USA 1.0 and place it in the base working directory and rename it to `baserom.dol`.
-	- To generate a linker map (takes a considerable amount of time), run `make MAPGENFLAG=1 -j`.
+	- To generate a linker map (takes a considerable amount of time), run `ninja -m` or  `make MAPGENFLAG=1 -j`.
 	- The project uses clang-format for a consistent style. Download the [correct version](https://cdn.discordapp.com/attachments/933849922418126918/1031358615300345856/clang-format.exe) and place in the main repo directory (e.g. `pikmin2/clang-format.exe`).
 
 * See [this video](https://youtu.be/CZXNQagqpkw) for a walkthrough of the steps on Windows (thanks Altafen for making this!).
@@ -69,12 +69,11 @@ This repository builds the following DOLs:
 	4. Decomp it!
 
 ### Generating Context for decomp.me Scratches
-(NB: The generator requires **Python 3** to run)
 
 - [decomp.me](https://decomp.me/) is an online decompilation sharing hub, allowing 'scratches' of functions to be generated and collaborated on.
 - Stand-alone decompilation packages and tools such as decomp.me require information on the functions and structures of the project in order to parse extracted blocks correctly. The easiest way to do this is to pass the tool just the necessary 'context' for the file, i.e. a set of all the headers used by the file that's being worked on.
 - A recursive context processing script is included in the repo (<a href="https://github.com/projectPiki/pikmin2/tree/main/tools/decompctx.py">tools/decompctx.py</a>), which generates a `ctx.c` file in the root directory.
 	- The contents of this can then be copied and pasted into the 'Context' section of a decomp.me scratch or similar.
 - To use, call the generator via the terminal/command line from the root directory (replacing DIRECTORY and FILE as required):
-    ```python3 tools/decompctx.py src/DIRECTORY/FILE.cpp```
+	```python tools/decompctx.py src/DIRECTORY/FILE.cpp```
 - Credit to encounter and the [Metroid Prime decomp project](https://github.com/PrimeDecomp/prime) for the script!

--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
+
 VERSION="${VERSION:=usa}"
+DEVKITPPC="${DEVKITPPC:=tools/devkitPPC}"
 OBJDUMP="$DEVKITPPC/bin/powerpc-eabi-objdump -Dz -bbinary -EB -mpowerpc -M gekko"
 if [ ! -z "$1" ]; then
   OPTIONS="--start-address=$(($1)) --stop-address=$(($2))"

--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 LIBS = [
     {
         "lib": "JStudio_JParticle",
@@ -1670,15 +1671,20 @@ if __name__ == "__main__":
     from shutil import which
     from tools import ninja_syntax
 
+    if sys.version_info < (3, 8):
+        sys.exit("Python 3.8 or later required.")
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--version",
+        "-v",
         dest="version",
         default="usa",
         help="version to build (usa, usa.demo)",
     )
     parser.add_argument(
         "--map",
+        "-m",
         dest="map",
         action="store_true",
         help="generate map file",
@@ -1716,6 +1722,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--debug",
+        "-d",
         dest="debug",
         action="store_true",
         help="build with debug info (non-matching)",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Extract devkitPPC archive
+zstandard>=0.22.0

--- a/tools/download_ppc.py
+++ b/tools/download_ppc.py
@@ -5,20 +5,8 @@ import platform
 import shutil
 import tempfile
 import tarfile
-from typing import Optional
+import zstandard
 
-
-try:
-    import zstandard
-except:
-    print("zstandard module not found, downloading...")
-    import subprocess
-    import sys
-
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "zstandard"], stdout=subprocess.DEVNULL)
-    import zstandard
-
-    print("zstandard module successfully downloaded!")
 
 # TODO: Less hardcoded elements
 REPO = "https://wii.leseratte10.de/devkitPro/devkitPPC/r44%20%282023-08-07%29/"


### PR DESCRIPTION
Removes the ugly built-in pip installer method with a proper `requirements.txt` like a normal repo should. Updated the readme to account for the new file, and reformatted a handful of things (mainly making Python 3.8 the minimum version). I'd like to figure out a way to automatically setup the compiler stuff as well, but that'll be at a later point.