### PR TITLE
Add ability to autogenerate context with ninja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.filters
 *.vcxproj
 *.user
+*.ctx
 include/*.s
 
 build/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,11 @@
         "editor.defaultFormatter": "ms-vscode.cpptools"
     },
     "editor.tabSize": 4,
+    "files.exclude": {
+        "**/*.ctx": true
+    },
     "files.associations": {
+        "*.ctx": "cpp",
         "source_location": "cpp",
         "types.h": "c",
         "rand.h": "c",

--- a/configure.py
+++ b/configure.py
@@ -116,7 +116,7 @@ LIBS = [
             ["JSystem/JKernel/JKRFileLoader", True],
             ["JSystem/JKernel/JKRHeap", False],
             ["JSystem/JKernel/JKRMemArchive", True],
-            ["JSystem/JKernel/JKRSolidHeap", True, {"mw_version" : "1.3.2"}],
+            ["JSystem/JKernel/JKRSolidHeap", True, {"mw_version": "1.3.2"}],
             ["JSystem/JKernel/JKRThread", True],
         ],
     },
@@ -1478,27 +1478,27 @@ LIBS = [
             ["plugProjectEbisawaU/ebiCardMgr", True],
             ["plugProjectEbisawaU/ebiScreenFramework", True],
             ["plugProjectEbisawaU/ebiScreenPushStart", True],
-            ["plugProjectEbisawaU/ebiScreenFileSelect", False, {"cflags" : "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiScreenFileSelect", False, {"cflags": "$cflags_pikmin -sym on"}],
             ["plugProjectEbisawaU/ebiScreenTitleMenu", True],
             ["plugProjectEbisawaU/ebiSaveMgr", True],
             ["plugProjectEbisawaU/ebiScreenSaveMenu", False],
-            ["plugProjectEbisawaU/ebiScreenFileSelect_Mgr", False, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiFileSelectMgr", True, {"cflags" : "$cflags_pikmin"}],
+            ["plugProjectEbisawaU/ebiScreenFileSelect_Mgr", False, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiFileSelectMgr", True, {"cflags": "$cflags_pikmin"}],
             ["plugProjectEbisawaU/ebiCardMgr_Load", True],
             ["plugProjectEbisawaU/ebiP2TitleCoordMgr", True],
-            ["plugProjectEbisawaU/ebiP2TitlePikmin", False, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiP2TitleKogane", True, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiP2TitleChappy", True, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiScreenTMBack", True, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiMainTitleMgr", False, {"cflags" : "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiP2TitlePikmin", False, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiP2TitleKogane", True, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiP2TitleChappy", True, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiScreenTMBack", True, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiMainTitleMgr", False, {"cflags": "$cflags_pikmin -sym on"}],
             ["plugProjectEbisawaU/ebiP2TitleFog", True],
-            ["plugProjectEbisawaU/efxEnemyBoss", False, {"cflags" : "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/efxEnemyBoss", False, {"cflags": "$cflags_pikmin -sym on"}],
             ["plugProjectEbisawaU/ebiCardEReader", True],
-            ["plugProjectEbisawaU/ebiScreenOmake", False, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiOmakeMgr", False, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiScreenOmakeCardE", False, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiScreenOmakeGame", True, {"cflags" : "$cflags_pikmin -sym on"}],
-            ["plugProjectEbisawaU/ebiScreenInfoWindow", True, {"cflags" : "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiScreenOmake", False, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiOmakeMgr", False, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiScreenOmakeCardE", False, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiScreenOmakeGame", True, {"cflags": "$cflags_pikmin -sym on"}],
+            ["plugProjectEbisawaU/ebiScreenInfoWindow", True, {"cflags": "$cflags_pikmin -sym on"}],
         ],
     },
     {
@@ -1658,6 +1658,7 @@ LIBS = [
     },
 ]
 
+
 def main():
     import os
     import io
@@ -1739,6 +1740,13 @@ def main():
         type=Path,
         default=Path("build"),
         help="base build directory",
+    )
+    parser.add_argument(
+        "--context",
+        "-c",
+        dest="context",
+        action="store_true",
+        help="generate context files for decomp.me",
     )
     args = parser.parse_args()
 
@@ -1874,6 +1882,7 @@ def main():
         # FIXME: Manual download because the above doesn't work for some reason
         if not Path("tools/powerpc").exists():
             import tools.download_ppc
+
             tools.download_ppc.main()
 
     if args.compilers == Path("tools/mwcc_compiler"):
@@ -1893,6 +1902,7 @@ def main():
         # FIXME: Manual download because the above doesn't work for some reason
         if not Path("tools/mwcc_compiler").exists():
             import tools.download_mwcc
+
             tools.download_mwcc.main()
 
     ###
@@ -1904,6 +1914,8 @@ def main():
     gnu_as = args.powerpc / f"powerpc-eabi-as{exe}"
 
     mwcc_cmd = f"{chain}{wine}{mwcc} $cflags -MMD -c $in -o $basedir"
+    if args.context:
+        mwcc_cmd += " && $python tools/decompctx.py $cfile -r -q"
     mwld_cmd = f"{wine}{mwld} $ldflags -o $out @$out.rsp"
     as_cmd = (
         f"{chain}{gnu_as} $asflags -o $out $in -MD $out.d"
@@ -2062,6 +2074,7 @@ def main():
                         "cflags": options["cflags"] or lib["cflags"],
                         "basedir": os.path.dirname(build_src_path / f"{object}"),
                         "basefile": path(build_src_path / f"{object}"),
+                        "cfile": path(c_file),
                     },
                 )
                 if lib["host"]:
@@ -2254,6 +2267,7 @@ def main():
     ###
     with open("objdiff.json", "w") as w:
         json.dump(objdiff_config, w, indent=4)
+
 
 if __name__ == "__main__":
     main()

--- a/tools/decompctx.py
+++ b/tools/decompctx.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import os
 import re
@@ -8,64 +6,74 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 root_dir = os.path.abspath(os.path.join(script_dir, ".."))
 src_dir = os.path.join(root_dir, "src")
 include_dir = os.path.join(root_dir, "include")
-stl_dir = os.path.join(root_dir, "include\stl")
+stl_dir = os.path.join(include_dir, "stl")
 
 include_pattern = re.compile(r'^#include\s*[<"](.+?)[>"]$')
-guard_pattern = re.compile(r'^#ifndef\s+(.*)$')
+guard_pattern = re.compile(r"^#ifndef\s+(.*)$")
 
-defines = set()
+defines: set[str] = set()
+quiet = False
+
 
 def import_h_file(in_file, r_path) -> str:
     rel_path = os.path.join(root_dir, r_path, in_file)
     inc_path = os.path.join(include_dir, in_file)
     stl_path = os.path.join(stl_dir, in_file)
     if os.path.exists(rel_path):
-      return import_c_file(rel_path)
+        return import_c_file(rel_path)
     elif os.path.exists(inc_path):
-      return import_c_file(inc_path)
+        return import_c_file(inc_path)
     elif os.path.exists(stl_path):
-      return import_c_file(stl_path)
+        return import_c_file(stl_path)
     else:
-      print("Failed to locate", in_file)
-      exit(1)
+        if not quiet:
+            print("Failed to locate", in_file)
+        exit(1)
+
 
 def import_c_file(in_file) -> str:
     in_file = os.path.relpath(in_file, root_dir)
-    out_text = ''
+    out_text = ""
 
     with open(in_file, encoding="shift-jis") as file:
-      for idx, line in enumerate(file):
-        guard_match = guard_pattern.match(line.strip())
-        if idx == 0:
-          if guard_match:
-            if guard_match[1] in defines:
-              break
-            defines.add(guard_match[1])
-          print("Processing file", in_file)
-        include_match = include_pattern.match(line.strip())
-        if include_match:
-          out_text += f"/* \"{in_file}\" line {idx} \"{include_match[1]}\" */\n"
-          out_text += import_h_file(include_match[1], os.path.dirname(in_file))
-          out_text += f"/* end \"{include_match[1]}\" */\n"
-        else:
-          out_text += line
+        for idx, line in enumerate(file):
+            guard_match = guard_pattern.match(line.strip())
+            if idx == 0:
+                if guard_match:
+                    if guard_match[1] in defines:
+                        break
+                    defines.add(guard_match[1])
+                if not quiet:
+                    print("Processing file", in_file)
+            include_match = include_pattern.match(line.strip())
+            if include_match:
+                out_text += f'/* "{in_file}" line {idx} "{include_match[1]}" */\n'
+                out_text += import_h_file(include_match[1], os.path.dirname(in_file))
+                out_text += f'/* end "{include_match[1]}" */\n'
+            else:
+                out_text += line
 
     return out_text
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        description="""Create a context file which can be used for decomp.me"""
-    )
+    parser = argparse.ArgumentParser(description="Create a context file which can be used for decomp.me")
+    parser.add_argument("c_file", help="File from which to create context")
     parser.add_argument(
-        "c_file",
-        help="""File from which to create context""",
+        "--relative", "-r", dest="relative", help="Extract context relative to the source file", action="store_true"
     )
+    parser.add_argument("--quiet", "-q", dest="quiet", help="Don't output anything", action="store_true")
     args = parser.parse_args()
 
-    output = import_c_file(args.c_file)
+    global quiet
+    quiet = args.quiet
 
-    with open(os.path.join(root_dir, "ctx.c"), "w", encoding="utf-8") as f:
-        f.write(output)
+    c_file = args.c_file
+    content = import_c_file(c_file)
+    filename = f"{c_file}.ctx" if args.relative else os.path.join(root_dir, "ctx.c")
+
+    with open(filename, "w", encoding="utf-8", newline="\n") as f:
+        f.write(content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of needing to always create a `ctx.c` if you want to upload a context file to `decomp.me`, this new `configure.py` option adds the ability to generate context files relative to any processed source file. Given a unique `.ctx` extension so they'll be hidden by default in VS Code, yet easily parseable in the standard explorer. Achieved by passing a `--context`/`-c` argument, this will regenerate automatically whenever `ninja` refreshes the respective file (even in `objdiff.exe`)

![23-12-21 16-06-45 explorer](https://github.com/projectPiki/pikmin2/assets/17489292/b3d63d1b-c7c0-4512-811b-cec50284de38)
