### PR TITLE
object-light

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -278,7 +278,7 @@ config.libs = [
         "mw_version": "GC/2.6",
         "host": True,
         "objects": [
-            Object(NonMatching, "JSystem/JStudio_JStage/object-light.cpp"),
+            Object(Matching, "JSystem/JStudio_JStage/object-light.cpp"),
             Object(Matching, "JSystem/JStudio_JStage/object.cpp"),
             Object(Matching, "JSystem/JStudio_JStage/object-actor.cpp"),
             Object(Matching, "JSystem/JStudio_JStage/object-ambientlight.cpp"),

--- a/include/Dolphin/mtx.h
+++ b/include/Dolphin/mtx.h
@@ -18,6 +18,7 @@ typedef f32 Mtx33[3][3];
 typedef f32 Mtx44[4][4];
 typedef f32 (*MtxP)[4];
 typedef f32 (*Mtx3P)[3];
+typedef const f32 (*CMtxP)[4]; // Change name later?
 typedef f32 PSQuaternion[4];
 
 typedef struct Quaternion {

--- a/include/JSystem/JStudio/TControl.h
+++ b/include/JSystem/JStudio/TControl.h
@@ -87,6 +87,39 @@ struct TControl : public stb::TControl {
 
 	f64 getSecondsPerFrame() const { return mSecondsPerFrame; }
 
+	bool transformOnSet_isEnabled() const { return mTransformOnSet; }
+	void transformOnSet_enable(bool param_0) { mTransformOnSet = param_0; }
+	bool transformOnGet_isEnabled() const { return mTransformOnGet; }
+	void transformOnGet_enable(bool param_0) { mTransformOnGet = param_0; }
+
+	f32 transformOnSet_getRotationY() const { return mTransformOnSet_RotY; }
+	CMtxP transformOnSet_getMatrix() const { return mTransformOnSet_Mtx; }
+	CMtxP transformOnGet_getMatrix() const { return mTransformOnGet_Mtx; }
+
+	const TTransform_position_direction* transformOnGet_transform_ifEnabled(const TTransform_position_direction& posDir,
+	                                                                        TTransform_position_direction* transformedPosDir) const
+	{
+		if (!transformOnGet_isEnabled()) {
+			return &posDir;
+		} else {
+			transformOnGet_transform(posDir, transformedPosDir);
+			return transformedPosDir;
+		}
+	}
+	void transformOnGet_transform(const TTransform_position_direction& posDir, TTransform_position_direction* transformedPosDir) const
+	{
+		transformOnGet_transformTranslation(posDir.mPosition, &transformedPosDir->mPosition);
+		transformOnGet_transformDirection(posDir.mDirection, &transformedPosDir->mDirection);
+	}
+	void transformOnGet_transformTranslation(const Vec& pos, Vec* transformedPos) const
+	{
+		PSMTXMultVec(transformOnGet_getMatrix(), &pos, transformedPos);
+	}
+	void transformOnGet_transformDirection(const Vec& dir, Vec* transformedDir) const
+	{
+		PSMTXMultVecSR(transformOnGet_getMatrix(), &dir, transformedDir);
+	}
+
 	// _00     = VTBL
 	// _00-_58 = stb::TControl
 	f64 mSecondsPerFrame;       // _58

--- a/src/JSystem/JStudio_JStage/object-light.cpp
+++ b/src/JSystem/JStudio_JStage/object-light.cpp
@@ -1,6 +1,9 @@
 #include "JSystem/JStudio_JStage.h"
 #include "stl/math.h"
 
+#define DEG_TO_RAD(degrees) (degrees * (PI / 180.0f))
+#define RAD_TO_DEG(radians) (radians * (180.0f / PI + 0.000005f)) // the 0.000005f is probably a fakematch
+
 namespace JStudio_JStage {
 
 TAdaptor_light::TVVOutput_direction_ TAdaptor_light::saoVVOutput_direction_[6]
@@ -43,24 +46,17 @@ void TAdaptor_light::adaptor_do_prepare(const JStudio::TObject* obj)
 void TAdaptor_light::adaptor_do_begin(const JStudio::TObject* object)
 {
 	mObject->setFlagOn(1);
-	JStudio::TControl* control = object->getControl(); // r29
+	JStudio::TControl* control = (JStudio::TControl*)object->getControl(); // r29
 	GXColor color              = mObject->JSGGetColor();
 	adaptor_setVariableValue_GXColor(sauVariableValue_4_COLOR_RGBA, color);
 
 	JStudio::TControl::TTransform_position_direction posDir;
+	JStudio::TControl::TTransform_position_direction transformedPosDir;
 	JStudio::TControl::TTransform_position_direction* vvVec = &posDir;
 	mObject->JSGGetPosition(&posDir.mPosition);
 	mObject->JSGGetDirection(&posDir.mDirection);
 
-	// this should probably be an inline
-	if (!control->mTransformOnGet) {
-		vvVec = &posDir;
-	} else {
-		JStudio::TControl::TTransform_position_direction transformedPosDir;
-		PSMTXMultVec(control->mTransformOnGet_Mtx, &posDir.mPosition, &transformedPosDir.mPosition);
-		PSMTXMultVecSR(control->mTransformOnGet_Mtx, &vvVec->mPosition, &transformedPosDir.mDirection);
-		vvVec = &transformedPosDir;
-	}
+	vvVec = (JStudio::TControl::TTransform_position_direction*)control->transformOnGet_transform_ifEnabled(posDir, &transformedPosDir);
 
 	adaptor_setVariableValue_Vec(sauVariableValue_3_POSITION_XYZ, vvVec->mPosition);
 
@@ -71,200 +67,12 @@ void TAdaptor_light::adaptor_do_begin(const JStudio::TObject* object)
 	f32 atanVal1 = dolatan2f(x, z);
 	f32 atanVal2 = dolatan2f(y, dist);
 
-	adaptor_setVariableValue_immediate(10, TODEGREES(atanVal1));
-	adaptor_setVariableValue_immediate(11, TODEGREES(atanVal2));
+	adaptor_setVariableValue_immediate(10, RAD_TO_DEG(atanVal1));
+	adaptor_setVariableValue_immediate(11, RAD_TO_DEG(atanVal2));
 
 	Vec targetPos;
 	PSVECAdd(&vvVec->mPosition, &vvVec->mDirection, &targetPos);
 	adaptor_setVariableValue_Vec(sauVariableValue_3_TARGET_POSITION_XYZ, targetPos);
-	/*
-	stwu     r1, -0x90(r1)
-	mflr     r0
-	stw      r0, 0x94(r1)
-	stfd     f31, 0x80(r1)
-	psq_st   f31, 136(r1), 0, qr0
-	stfd     f30, 0x70(r1)
-	psq_st   f30, 120(r1), 0, qr0
-	stfd     f29, 0x60(r1)
-	psq_st   f29, 104(r1), 0, qr0
-	stw      r31, 0x5c(r1)
-	stw      r30, 0x58(r1)
-	stw      r29, 0x54(r1)
-	mr       r30, r3
-	mr       r29, r4
-	lwz      r31, 0x114(r3)
-	mr       r3, r31
-	lwz      r12, 0(r31)
-	lwz      r12, 0x18(r12)
-	mtctr    r12
-	bctrl
-	lwz      r12, 0(r31)
-	ori      r4, r3, 1
-	mr       r3, r31
-	lwz      r12, 0x1c(r12)
-	mtctr    r12
-	bctrl
-	lwz      r3, 0x114(r30)
-	lwz      r29, 0x14(r29)
-	lwz      r12, 0(r3)
-	lwz      r12, 0x4c(r12)
-	mtctr    r12
-	bctrl
-	lis      r4, sauVariableValue_4_COLOR_RGBA__Q27JStudio14TAdaptor_light@ha
-	stw      r3, 0xc(r1)
-	addi     r4, r4, sauVariableValue_4_COLOR_RGBA__Q27JStudio14TAdaptor_light@l
-	mr       r3, r30
-	addi     r5, r1, 0xc
-	bl adaptor_setVariableValue_GXColor__Q27JStudio8TAdaptorFPCUlRC8_GXColor lwz
-r3, 0x114(r30) addi     r4, r1, 0x34 lwz      r12, 0(r3) lwz      r12, 0x44(r12)
-	mtctr    r12
-	bctrl
-	lwz      r3, 0x114(r30)
-	addi     r31, r1, 0x40
-	mr       r4, r31
-	lwz      r12, 0(r3)
-	lwz      r12, 0x64(r12)
-	mtctr    r12
-	bctrl
-	lbz      r0, 0x75(r29)
-	cmplwi   r0, 0
-	bne      lbl_80011610
-	addi     r31, r1, 0x34
-	b        lbl_80011634
-
-lbl_80011610:
-	addi     r3, r29, 0xc8
-	addi     r4, r1, 0x34
-	addi     r5, r1, 0x1c
-	bl       PSMTXMultVec
-	mr       r4, r31
-	addi     r3, r29, 0xc8
-	addi     r5, r1, 0x28
-	bl       PSMTXMultVecSR
-	addi     r31, r1, 0x1c
-
-lbl_80011634:
-	lis      r3, sauVariableValue_3_POSITION_XYZ__Q27JStudio14TAdaptor_light@ha
-	mr       r5, r31
-	addi     r4, r3,
-sauVariableValue_3_POSITION_XYZ__Q27JStudio14TAdaptor_light@l mr       r3, r30
-	bl       adaptor_setVariableValue_Vec__Q27JStudio8TAdaptorFPCUlRC3Vec
-	lfs      f2, 0x14(r31)
-	lfs      f1, 0xc(r31)
-	fmuls    f3, f2, f2
-	lfs      f0, lbl_80516480@sda21(r2)
-	lfs      f30, 0x10(r31)
-	fmadds   f31, f1, f1, f3
-	fcmpo    cr0, f31, f0
-	ble      lbl_800116B0
-	frsqrte  f3, f31
-	lfd      f5, lbl_80516488@sda21(r2)
-	lfd      f4, lbl_80516490@sda21(r2)
-	fmul     f0, f3, f3
-	fmul     f3, f5, f3
-	fnmsub   f0, f31, f0, f4
-	fmul     f3, f3, f0
-	fmul     f0, f3, f3
-	fmul     f3, f5, f3
-	fnmsub   f0, f31, f0, f4
-	fmul     f3, f3, f0
-	fmul     f0, f3, f3
-	fmul     f3, f5, f3
-	fnmsub   f0, f31, f0, f4
-	fmul     f0, f3, f0
-	fmul     f31, f31, f0
-	frsp     f31, f31
-	b        lbl_80011734
-
-lbl_800116B0:
-	lfd      f0, lbl_80516498@sda21(r2)
-	fcmpo    cr0, f31, f0
-	bge      lbl_800116C8
-	lis      r3, __float_nan@ha
-	lfs      f31, __float_nan@l(r3)
-	b        lbl_80011734
-
-lbl_800116C8:
-	stfs     f31, 8(r1)
-	lis      r0, 0x7f80
-	lwz      r4, 8(r1)
-	rlwinm   r3, r4, 0, 1, 8
-	cmpw     r3, r0
-	beq      lbl_800116F0
-	bge      lbl_80011720
-	cmpwi    r3, 0
-	beq      lbl_80011708
-	b        lbl_80011720
-
-lbl_800116F0:
-	clrlwi.  r0, r4, 9
-	beq      lbl_80011700
-	li       r0, 1
-	b        lbl_80011724
-
-lbl_80011700:
-	li       r0, 2
-	b        lbl_80011724
-
-lbl_80011708:
-	clrlwi.  r0, r4, 9
-	beq      lbl_80011718
-	li       r0, 5
-	b        lbl_80011724
-
-lbl_80011718:
-	li       r0, 3
-	b        lbl_80011724
-
-lbl_80011720:
-	li       r0, 4
-
-lbl_80011724:
-	cmpwi    r0, 1
-	bne      lbl_80011734
-	lis      r3, __float_nan@ha
-	lfs      f31, __float_nan@l(r3)
-
-lbl_80011734:
-	bl       atan2
-	frsp     f29, f1
-	fmr      f1, f30
-	fmr      f2, f31
-	bl       atan2
-	lis      r3,
-update_immediate___Q27JStudio14TVariableValueFPQ27JStudio14TVariableValued@ha
-	lwz      r6, 4(r30)
-	addi     r7, r3,
-update_immediate___Q27JStudio14TVariableValueFPQ27JStudio14TVariableValued@l lfs
-f2, lbl_805164A0@sda21(r2) stw      r7, 0xd0(r6) li       r0, 0 fmuls    f0, f2,
-f29 mr       r3, r31 stw      r0, 0xcc(r6) frsp     f1, f1 addi     r4, r31, 0xc
-	addi     r5, r1, 0x10
-	stfs     f0, 0xd4(r6)
-	fmuls    f0, f2, f1
-	lwz      r6, 4(r30)
-	stw      r7, 0xe4(r6)
-	stw      r0, 0xe0(r6)
-	stfs     f0, 0xe8(r6)
-	bl       PSVECAdd
-	lis      r4,
-sauVariableValue_3_TARGET_POSITION_XYZ__Q27JStudio14TAdaptor_light@ha mr r3, r30
-	addi     r4, r4,
-sauVariableValue_3_TARGET_POSITION_XYZ__Q27JStudio14TAdaptor_light@l addi r5,
-r1, 0x10 bl       adaptor_setVariableValue_Vec__Q27JStudio8TAdaptorFPCUlRC3Vec
-	psq_l    f31, 136(r1), 0, qr0
-	lfd      f31, 0x80(r1)
-	psq_l    f30, 120(r1), 0, qr0
-	lfd      f30, 0x70(r1)
-	psq_l    f29, 104(r1), 0, qr0
-	lfd      f29, 0x60(r1)
-	lwz      r31, 0x5c(r1)
-	lwz      r30, 0x58(r1)
-	lwz      r0, 0x94(r1)
-	lwz      r29, 0x54(r1)
-	mtlr     r0
-	addi     r1, r1, 0x90
-	blr
-	*/
 }
 
 /**
@@ -291,12 +99,12 @@ void TAdaptor_light::adaptor_do_update(const JStudio::TObject* object, u32 p2)
 	case 1:
 		f32 val10 = adaptor_getVariableValue(10)->getValue();
 		f32 val11 = adaptor_getVariableValue(11)->getValue();
-		f32 cosX  = dolcosf(DEG2RAD * val11);
-		f32 sinX  = dolsinf(DEG2RAD * val11);
+		f32 cosX  = dolcosf(DEG_TO_RAD(val11));
+		f32 sinX  = dolsinf(DEG_TO_RAD(val11));
 
-		posDir1.mDirection.x = cosX * dolsinf(DEG2RAD * val10);
+		posDir1.mDirection.x = cosX * dolsinf(DEG_TO_RAD(val10));
 		posDir1.mDirection.y = sinX;
-		posDir1.mDirection.z = cosX * dolcosf(DEG2RAD * val10);
+		posDir1.mDirection.z = cosX * dolcosf(DEG_TO_RAD(val10));
 
 		break;
 	case 2:


### PR DESCRIPTION
matched with inlines from TWW/TP debug and some casts

I don't know what's going on with the degree/radian conversion macros, the ones in math.h produce the wrong float literals in .sdata2 so I added separate ones for just this file, but I assume this can be cleaned up somehow