### PR TITLE
JASTrack.cpp: Port intel about loadTbl from Pikmin 1.

### DIFF
--- a/include/JSystem/JAudio/JAS/JASTrack.h
+++ b/include/JSystem/JAudio/JAS/JASTrack.h
@@ -310,7 +310,7 @@ struct JASTrack : public JSUList<JASChannel> {
 	void getDolby() const;
 	void updateOscParam(int, f32);
 	void muteChildTracks(u16);
-	void loadTbl(u32, u32, u32);
+	u32 loadTbl(u32, u32, u32);
 	JASTrack* routeTrack(u32 count);
 	void routeTrack(u32) const;
 	void checkExportApp(u32) const;

--- a/src/JSystem/JAudio/JAS/JASSeqCtrl.cpp
+++ b/src/JSystem/JAudio/JAS/JASSeqCtrl.cpp
@@ -151,8 +151,8 @@ u32 JASSeqCtrl::get32(u32 offset) const
  */
 u16 JASSeqCtrl::read16()
 {
-	u16 result = *(mCurrentFilePtr++) << 8;
-	result |= *(mCurrentFilePtr++);
+	u16 result = readByte() << 8;
+	result |= readByte();
 	return result;
 }
 
@@ -162,10 +162,10 @@ u16 JASSeqCtrl::read16()
  */
 u32 JASSeqCtrl::read24()
 {
-	u32 result = *(mCurrentFilePtr++) << 8;
-	result |= *(mCurrentFilePtr++);
+	u32 result = readByte() << 8;
+	result |= readByte();
 	result <<= 8;
-	result |= *(mCurrentFilePtr++);
+	result |= readByte();
 	return result;
 }
 
@@ -175,5 +175,11 @@ u32 JASSeqCtrl::read24()
  */
 u32 JASSeqCtrl::read32()
 {
-	// UNUSED FUNCTION
+	// UNUSED FUNCTION speculation (size matches)
+	u32 result = readByte() << 8;
+	result |= readByte();
+	result <<= 16;
+	result |= readByte() << 8;
+	result |= readByte();
+	return result;
 }

--- a/src/JSystem/JAudio/JAS/JASSeqParser.cpp
+++ b/src/JSystem/JAudio/JAS/JASSeqParser.cpp
@@ -805,12 +805,12 @@ int JASSeqParser::cmdPrintf(JASTrack* track, u32* args)
 	u32 count = 0;
 
 	for (u32 i = 0; i < 128; i++) {
-		buf[i] = *track->getSeq()->mCurrentFilePtr++;
+		buf[i] = track->getSeq()->readByte();
 		if (!buf[i]) {
 			break;
 		}
 		if (buf[i] == '\\') {
-			buf[i] = *track->getSeq()->mCurrentFilePtr++;
+			buf[i] = track->getSeq()->readByte();
 			if (!buf[i]) {
 				break;
 			}
@@ -828,7 +828,7 @@ int JASSeqParser::cmdPrintf(JASTrack* track, u32* args)
 			continue;
 		}
 
-		buf[++i] = *track->getSeq()->mCurrentFilePtr++;
+		buf[++i] = track->getSeq()->readByte();
 		if (!buf[i]) {
 			break;
 		}
@@ -860,7 +860,7 @@ int JASSeqParser::cmdPrintf(JASTrack* track, u32* args)
 	}
 
 	for (u32 i = 0; i < count; i++) {
-		registers[i] = *track->getSeq()->mCurrentFilePtr++;
+		registers[i] = track->getSeq()->readByte();
 		if (byteArray[i] == 2) {
 			registers[i] = (int)&track->getSeq()->mRawFilePtr[registers[i]];
 		} else if (byteArray[i] == 5) {
@@ -1082,7 +1082,7 @@ int JASSeqParser::cmdNoteOn(JASTrack* track, u8 note)
 			val24 = track->exchangeRegisterValue(val24 - 1);
 		}
 		if (val28 & 1) {
-			val23 = track->exchangeRegisterValue(*ctrl->mCurrentFilePtr++);
+			val23 = track->exchangeRegisterValue(ctrl->readByte());
 			val28 ^= 1;
 		}
 


### PR DESCRIPTION
This unfortunately makes the matching % lower due unsolved regalloc issues, but it should be closer to the truth.  `JASTrack::loadTbl` matches from size with minor modifications to it's Pikmin 1 counterpart.