### PR TITLE
Add NUM_PIKI_ICONS

### DIFF
--- a/include/og/Screen/ogScreen.h
+++ b/include/og/Screen/ogScreen.h
@@ -92,9 +92,9 @@ void TagToName(u64, char*);
 // Unused
 void setBlendPane(J2DBlendInfo, J2DScreen*, u64*);
 
-extern const char* PikiIconTextureName[19];
-
-extern ResTIMG* PikiIconTextureResTIMG[19];
+#define NUM_PIKI_ICONS (19)
+extern const char* PikiIconTextureName[NUM_PIKI_ICONS];
+extern ResTIMG* PikiIconTextureResTIMG[NUM_PIKI_ICONS];
 
 } // namespace Screen
 } // namespace og

--- a/src/plugProjectKandoU/navi.cpp
+++ b/src/plugProjectKandoU/navi.cpp
@@ -5857,7 +5857,7 @@ void Navi::findNextThrowPiki()
 u32 Navi::ogGetNextThrowPiki()
 {
 	Piki* nextPiki = mNextThrowPiki;
-	return (!nextPiki) ? 0 : ((3 * nextPiki->mPikiKind) + 1) + nextPiki->mHappaKind;
+	return (!nextPiki) ? 0 : ((PikiGrowthStageCount * nextPiki->mPikiKind) + 1) + nextPiki->mHappaKind;
 }
 
 // extern f32 pikmin2_cosf(f32 theta);

--- a/src/plugProjectOgawaU/ogCatchPiki.cpp
+++ b/src/plugProjectOgawaU/ogCatchPiki.cpp
@@ -30,7 +30,7 @@ void CallBack_CatchPiki::init(J2DScreen* screen, u64 tag, u32* pikiType, JKRArch
 	char** iconNames   = (char**)PikiIconTextureName;
 	ResTIMG** textures = PikiIconTextureResTIMG;
 
-	for (int i = 0; i < 19; i++) {
+	for (int i = 0; i < NUM_PIKI_ICONS; i++) {
 		textures[i] = static_cast<ResTIMG*>(archive->getResource('TIMG', iconNames[i]));
 	}
 
@@ -46,7 +46,7 @@ void CallBack_CatchPiki::update()
 {
 	if (mPikiType && mPikiIcon) {
 		u32 pikiType = *mPikiType;
-		if (pikiType != mCurrPikiType && pikiType < 19) {
+		if (pikiType != mCurrPikiType && pikiType < NUM_PIKI_ICONS) {
 			setPikiIcon(pikiType);
 			mScaleMgr.up(0.4f, 30.0f, 0.7f, 0.0f);
 			mCurrPikiType = pikiType;
@@ -64,7 +64,7 @@ void CallBack_CatchPiki::update()
  */
 void CallBack_CatchPiki::setPikiIcon(int pikiType)
 {
-	if (pikiType < 19) {
+	if (pikiType < NUM_PIKI_ICONS) {
 		mPikiIcon->changeTexture(PikiIconTextureResTIMG[pikiType], 0);
 	}
 }

--- a/src/plugProjectOgawaU/ogScreen.cpp
+++ b/src/plugProjectOgawaU/ogScreen.cpp
@@ -9,7 +9,7 @@
 namespace og {
 namespace Screen {
 
-ResTIMG* PikiIconTextureResTIMG[19];
+ResTIMG* PikiIconTextureResTIMG[NUM_PIKI_ICONS];
 
 static void _Print(char* format, ...)
 {
@@ -221,9 +221,13 @@ u64 maskTag(u64 tag, u16 num, u16 mask)
 }
 
 const char* PikiIconTextureName[]
-    = { "toumei_piki.bti", "bp_l64.bti", "bp_b64.bti", "bp_f64.bti",  "rp_l64.bti",  "rp_b64.bti",  "rp_f64.bti",
-	    "yp_l64.bti",      "yp_b64.bti", "yp_f64.bti", "blp_l64.bti", "blp_b64.bti", "blp_f64.bti", "wp_l64.bti",
-	    "wp_b64.bti",      "wp_f64.bti", "cha_l.bti",  "cha_b.bti",   "cha_f.bti" };
+    = { "toumei_piki.bti",
+	    "bp_l64.bti",  "bp_b64.bti",  "bp_f64.bti",
+	    "rp_l64.bti",  "rp_b64.bti",  "rp_f64.bti",
+	    "yp_l64.bti",  "yp_b64.bti",  "yp_f64.bti",
+	    "blp_l64.bti", "blp_b64.bti", "blp_f64.bti",
+	    "wp_l64.bti",  "wp_b64.bti",  "wp_f64.bti",
+	    "cha_l.bti",   "cha_b.bti",   "cha_f.bti" };
 
 /**
  * @note Address: 0x803029C0


### PR DESCRIPTION
Add a new `#define` for the "magic 19s" that are sprinkled around. Makes it much easier and less error-prone to add additional piki icons.