### PR TITLE
match J2DTevBlock setTevSwapModeInfo

### DIFF
--- a/include/JSystem/J2D/J2DTypes.h
+++ b/include/JSystem/J2D/J2DTypes.h
@@ -358,11 +358,13 @@ struct J2DTevStage {
 
 	void setTevSwapModeInfo(const J2DTevSwapModeInfo& swapInfo)
 	{
-		setTexSel(swapInfo.mTexSel);
+		setTexSel(static_cast<u32>(swapInfo.mTexSel));
 		setRasSel(swapInfo.mRasSel);
 	}
 
 	void setTexSel(u8 texSel) { _07 = (_07 & ~0xC) | (texSel << 2); }
+
+	void setTexSel(u32 texSel) { _07 = (_07 & ~0xC) | (texSel << 2); }
 
 	void setRasSel(u8 rasSel) { _07 = (_07 & ~0x3) | (u8)rasSel; }
 


### PR DESCRIPTION
Matches the `setTevSwapModeInfo` implementations for `J2DTevBlock1`,
`J2DTevBlock2`, `J2DTevBlock4`, `J2DTevBlock8`, and `J2DTevBlock16`.

Progress:
- +280 matched code bytes
- +5 matched functions
- no matching regressions

Verification:
- Full Ninja build completed successfully
- `build/GPVE01/main.dol: OK`