### PR TITLE
match most of cellPyramid.cpp

### DIFF
--- a/src/plugProjectKandoU/cellPyramid.cpp
+++ b/src/plugProjectKandoU/cellPyramid.cpp
@@ -18,8 +18,8 @@ u8 CellPyramid::sSpeedUpResolveColl;
 CellPyramid* Cell::sCurrCellMgr;
 int CellPyramid::sCellBugID;
 
-u8 CellPyramid::sOptResolveColl = 1;
-char* CellPyramid::sCellBugName = "cellPyramid";
+u8 CellPyramid::sOptResolveColl     = 2;
+static const char cellPyramidName[] = "cellPyramid";
 
 /**
  * @note Address: 0x801565C8
@@ -827,481 +827,35 @@ void CellLayer::pileup(CellLayer& layer)
 		mCells[i].mLayerIdx = mLayerIdx;
 	}
 
-	for (int x2 = 0, x1 = 0; x1 < mSizeX; x2 += 2, x1++) {
-		for (int y2 = 0, y1 = 0; y1 < mSizeY; y2 += 2, y1++) {
+	int y2;
+	int x2;
+	int x1;
+	int y1;
+	for (x1 = 0, x2 = 0; x1 < mSizeX; x2 += 2, x1++) {
+		for (y1 = 0, y2 = 0; y1 < mSizeY; y2 += 2, y1++) {
 			Cell* currCell                 = (*this)(x1, y1);
-			currCell->mNeighboringCells[0] = (*this)(x2, y2);
-			currCell->mNeighboringCells[1] = (*this)(x2 + 1, y2);
-			currCell->mNeighboringCells[2] = (*this)(x2, y2 + 1);
-			currCell->mNeighboringCells[3] = (*this)(x2 + 1, y2 + 1);
+			currCell->mNeighboringCells[0] = layer(x2, y2);
+			currCell->mNeighboringCells[1] = layer(x2 + 1, y2);
+			currCell->mNeighboringCells[2] = layer(x2, y2 + 1);
+			currCell->mNeighboringCells[3] = layer(x2 + 1, y2 + 1);
 
-			if ((*this)(x2, y2)) {
-				(*this)(x2, y2)->mHeadCell = currCell;
+			if (layer(x2, y2)) {
+				layer(x2, y2)->mHeadCell = currCell;
 			}
 
-			if ((*this)(x2 + 1, y2)) {
-				(*this)(x2 + 1, y2)->mHeadCell = currCell;
+			if (layer(x2 + 1, y2)) {
+				layer(x2 + 1, y2)->mHeadCell = currCell;
 			}
 
-			if ((*this)(x2, y2 + 1)) {
-				(*this)(x2, y2 + 1)->mHeadCell = currCell;
+			if (layer(x2, y2 + 1)) {
+				layer(x2, y2 + 1)->mHeadCell = currCell;
 			}
 
-			if ((*this)(x2 + 1, y2 + 1)) {
-				(*this)(x2 + 1, y2 + 1)->mHeadCell = currCell;
+			if (layer(x2 + 1, y2 + 1)) {
+				layer(x2 + 1, y2 + 1)->mHeadCell = currCell;
 			}
 		}
 	}
-	/*
-	stwu     r1, -0x40(r1)
-	mflr     r0
-	lfd      f2, lbl_80518638@sda21(r2)
-	stw      r0, 0x44(r1)
-	lis      r0, 0x4330
-	lfs      f0, lbl_80518630@sda21(r2)
-	stw      r31, 0x3c(r1)
-	mr       r31, r4
-	stw      r30, 0x38(r1)
-	mr       r30, r3
-	stw      r29, 0x34(r1)
-	lhz      r4, 4(r4)
-	stw      r0, 8(r1)
-	rlwinm   r0, r4, 1, 0x10, 0x1e
-	sth      r0, 4(r3)
-	lhz      r3, 6(r31)
-	addi     r0, r3, 1
-	sth      r0, 6(r30)
-	lhz      r0, 0(r31)
-	stw      r0, 0xc(r1)
-	lfd      f1, 8(r1)
-	fsubs    f1, f1, f2
-	fmuls    f1, f1, f0
-	bl       ceil
-	frsp     f0, f1
-	lis      r0, 0x4330
-	stw      r0, 0x18(r1)
-	lfd      f2, lbl_80518638@sda21(r2)
-	fctiwz   f1, f0
-	lfs      f0, lbl_80518630@sda21(r2)
-	stfd     f1, 0x10(r1)
-	lwz      r0, 0x14(r1)
-	sth      r0, 0(r30)
-	lhz      r0, 2(r31)
-	stw      r0, 0x1c(r1)
-	lfd      f1, 0x18(r1)
-	fsubs    f1, f1, f2
-	fmuls    f1, f1, f0
-	bl       ceil
-	frsp     f0, f1
-	fctiwz   f0, f0
-	stfd     f0, 0x20(r1)
-	lwz      r0, 0x24(r1)
-	sth      r0, 2(r30)
-	lhz      r3, 0(r30)
-	lhz      r0, 2(r30)
-	mullw    r29, r3, r0
-	mulli    r3, r29, 0x2c
-	addi     r3, r3, 0x10
-	bl       __nwa__FUl
-	lis      r4, __ct__Q24Game4CellFv@ha
-	mr       r7, r29
-	addi     r4, r4, __ct__Q24Game4CellFv@l
-	li       r5, 0
-	li       r6, 0x2c
-	bl       __construct_new_array
-	stw      r3, 8(r30)
-	li       r5, 0
-	li       r6, 0
-	stw      r5, 0x2c(r30)
-	stw      r5, 0x30(r30)
-	b        lbl_80157E54
-
-lbl_80157E3C:
-	lhz      r4, 6(r30)
-	addi     r0, r5, 0x28
-	lwz      r3, 8(r30)
-	addi     r5, r5, 0x2c
-	addi     r6, r6, 1
-	sthx     r4, r3, r0
-
-lbl_80157E54:
-	lhz      r3, 0(r30)
-	lhz      r0, 2(r30)
-	mullw    r0, r3, r0
-	cmpw     r6, r0
-	blt      lbl_80157E3C
-	li       r6, 0
-	li       r5, 0
-	b        lbl_80158294
-
-lbl_80157E74:
-	li       r7, 0
-	li       r4, 0
-	b        lbl_80158280
-
-lbl_80157E80:
-	cmpwi    r6, 0
-	blt      lbl_80157EA4
-	cmpwi    r7, 0
-	blt      lbl_80157EA4
-	lhz      r3, 0(r30)
-	cmpw     r6, r3
-	bge      lbl_80157EA4
-	cmpw     r7, r0
-	blt      lbl_80157EAC
-
-lbl_80157EA4:
-	li       r3, 0
-	b        lbl_80157EC0
-
-lbl_80157EAC:
-	mullw    r0, r7, r3
-	lwz      r3, 8(r30)
-	add      r0, r6, r0
-	mulli    r0, r0, 0x2c
-	add      r3, r3, r0
-
-lbl_80157EC0:
-	cmpwi    r5, 0
-	blt      lbl_80157EE8
-	cmpwi    r4, 0
-	blt      lbl_80157EE8
-	lhz      r8, 0(r31)
-	cmpw     r5, r8
-	bge      lbl_80157EE8
-	lhz      r0, 2(r31)
-	cmpw     r4, r0
-	blt      lbl_80157EF0
-
-lbl_80157EE8:
-	li       r8, 0
-	b        lbl_80157F04
-
-lbl_80157EF0:
-	mullw    r0, r4, r8
-	lwz      r8, 8(r31)
-	add      r0, r5, r0
-	mulli    r0, r0, 0x2c
-	add      r8, r8, r0
-
-lbl_80157F04:
-	addic.   r0, r5, 1
-	stw      r8, 0(r3)
-	blt      lbl_80157F34
-	cmpwi    r4, 0
-	blt      lbl_80157F34
-	lhz      r8, 0(r31)
-	addi     r0, r5, 1
-	cmpw     r0, r8
-	bge      lbl_80157F34
-	lhz      r0, 2(r31)
-	cmpw     r4, r0
-	blt      lbl_80157F3C
-
-lbl_80157F34:
-	li       r0, 0
-	b        lbl_80157F54
-
-lbl_80157F3C:
-	mullw    r0, r4, r8
-	lwz      r9, 8(r31)
-	add      r8, r5, r0
-	addi     r0, r8, 1
-	mulli    r0, r0, 0x2c
-	add      r0, r9, r0
-
-lbl_80157F54:
-	cmpwi    r5, 0
-	stw      r0, 4(r3)
-	blt      lbl_80157F84
-	addic.   r0, r4, 1
-	blt      lbl_80157F84
-	lhz      r9, 0(r31)
-	cmpw     r5, r9
-	bge      lbl_80157F84
-	lhz      r0, 2(r31)
-	addi     r8, r4, 1
-	cmpw     r8, r0
-	blt      lbl_80157F8C
-
-lbl_80157F84:
-	li       r8, 0
-	b        lbl_80157FA0
-
-lbl_80157F8C:
-	mullw    r0, r8, r9
-	lwz      r8, 8(r31)
-	add      r0, r5, r0
-	mulli    r0, r0, 0x2c
-	add      r8, r8, r0
-
-lbl_80157FA0:
-	addic.   r0, r5, 1
-	stw      r8, 8(r3)
-	blt      lbl_80157FD4
-	addic.   r0, r4, 1
-	blt      lbl_80157FD4
-	lhz      r9, 0(r31)
-	addi     r0, r5, 1
-	cmpw     r0, r9
-	bge      lbl_80157FD4
-	lhz      r0, 2(r31)
-	addi     r8, r4, 1
-	cmpw     r8, r0
-	blt      lbl_80157FDC
-
-lbl_80157FD4:
-	li       r0, 0
-	b        lbl_80157FF4
-
-lbl_80157FDC:
-	mullw    r0, r8, r9
-	lwz      r9, 8(r31)
-	add      r8, r5, r0
-	addi     r0, r8, 1
-	mulli    r0, r0, 0x2c
-	add      r0, r9, r0
-
-lbl_80157FF4:
-	cmpwi    r5, 0
-	stw      r0, 0xc(r3)
-	blt      lbl_80158020
-	cmpwi    r4, 0
-	blt      lbl_80158020
-	lhz      r8, 0(r31)
-	cmpw     r5, r8
-	bge      lbl_80158020
-	lhz      r0, 2(r31)
-	cmpw     r4, r0
-	blt      lbl_80158028
-
-lbl_80158020:
-	li       r0, 0
-	b        lbl_8015803C
-
-lbl_80158028:
-	mullw    r0, r4, r8
-	lwz      r8, 8(r31)
-	add      r0, r5, r0
-	mulli    r0, r0, 0x2c
-	add      r0, r8, r0
-
-lbl_8015803C:
-	cmplwi   r0, 0
-	beq      lbl_8015808C
-	cmpwi    r5, 0
-	blt      lbl_8015806C
-	cmpwi    r4, 0
-	blt      lbl_8015806C
-	lhz      r8, 0(r31)
-	cmpw     r5, r8
-	bge      lbl_8015806C
-	lhz      r0, 2(r31)
-	cmpw     r4, r0
-	blt      lbl_80158074
-
-lbl_8015806C:
-	li       r8, 0
-	b        lbl_80158088
-
-lbl_80158074:
-	mullw    r0, r4, r8
-	lwz      r8, 8(r31)
-	add      r0, r5, r0
-	mulli    r0, r0, 0x2c
-	add      r8, r8, r0
-
-lbl_80158088:
-	stw      r3, 0x10(r8)
-
-lbl_8015808C:
-	addic.   r0, r5, 1
-	blt      lbl_801580B8
-	cmpwi    r4, 0
-	blt      lbl_801580B8
-	lhz      r8, 0(r31)
-	addi     r0, r5, 1
-	cmpw     r0, r8
-	bge      lbl_801580B8
-	lhz      r0, 2(r31)
-	cmpw     r4, r0
-	blt      lbl_801580C0
-
-lbl_801580B8:
-	li       r0, 0
-	b        lbl_801580D8
-
-lbl_801580C0:
-	mullw    r0, r4, r8
-	lwz      r9, 8(r31)
-	add      r8, r5, r0
-	addi     r0, r8, 1
-	mulli    r0, r0, 0x2c
-	add      r0, r9, r0
-
-lbl_801580D8:
-	cmplwi   r0, 0
-	beq      lbl_80158130
-	addic.   r0, r5, 1
-	blt      lbl_8015810C
-	cmpwi    r4, 0
-	blt      lbl_8015810C
-	lhz      r8, 0(r31)
-	addi     r0, r5, 1
-	cmpw     r0, r8
-	bge      lbl_8015810C
-	lhz      r0, 2(r31)
-	cmpw     r4, r0
-	blt      lbl_80158114
-
-lbl_8015810C:
-	li       r8, 0
-	b        lbl_8015812C
-
-lbl_80158114:
-	mullw    r0, r4, r8
-	lwz      r9, 8(r31)
-	add      r8, r5, r0
-	addi     r0, r8, 1
-	mulli    r0, r0, 0x2c
-	add      r8, r9, r0
-
-lbl_8015812C:
-	stw      r3, 0x10(r8)
-
-lbl_80158130:
-	cmpwi    r5, 0
-	blt      lbl_8015815C
-	addic.   r0, r4, 1
-	blt      lbl_8015815C
-	lhz      r9, 0(r31)
-	cmpw     r5, r9
-	bge      lbl_8015815C
-	lhz      r0, 2(r31)
-	addi     r8, r4, 1
-	cmpw     r8, r0
-	blt      lbl_80158164
-
-lbl_8015815C:
-	li       r0, 0
-	b        lbl_80158178
-
-lbl_80158164:
-	mullw    r0, r8, r9
-	lwz      r8, 8(r31)
-	add      r0, r5, r0
-	mulli    r0, r0, 0x2c
-	add      r0, r8, r0
-
-lbl_80158178:
-	cmplwi   r0, 0
-	beq      lbl_801581CC
-	cmpwi    r5, 0
-	blt      lbl_801581AC
-	addic.   r0, r4, 1
-	blt      lbl_801581AC
-	lhz      r9, 0(r31)
-	cmpw     r5, r9
-	bge      lbl_801581AC
-	lhz      r0, 2(r31)
-	addi     r8, r4, 1
-	cmpw     r8, r0
-	blt      lbl_801581B4
-
-lbl_801581AC:
-	li       r8, 0
-	b        lbl_801581C8
-
-lbl_801581B4:
-	mullw    r0, r8, r9
-	lwz      r8, 8(r31)
-	add      r0, r5, r0
-	mulli    r0, r0, 0x2c
-	add      r8, r8, r0
-
-lbl_801581C8:
-	stw      r3, 0x10(r8)
-
-lbl_801581CC:
-	addic.   r0, r5, 1
-	blt      lbl_801581FC
-	addic.   r0, r4, 1
-	blt      lbl_801581FC
-	lhz      r9, 0(r31)
-	addi     r0, r5, 1
-	cmpw     r0, r9
-	bge      lbl_801581FC
-	lhz      r0, 2(r31)
-	addi     r8, r4, 1
-	cmpw     r8, r0
-	blt      lbl_80158204
-
-lbl_801581FC:
-	li       r0, 0
-	b        lbl_8015821C
-
-lbl_80158204:
-	mullw    r0, r8, r9
-	lwz      r9, 8(r31)
-	add      r8, r5, r0
-	addi     r0, r8, 1
-	mulli    r0, r0, 0x2c
-	add      r0, r9, r0
-
-lbl_8015821C:
-	cmplwi   r0, 0
-	beq      lbl_80158278
-	addic.   r0, r5, 1
-	blt      lbl_80158254
-	addic.   r0, r4, 1
-	blt      lbl_80158254
-	lhz      r9, 0(r31)
-	addi     r0, r5, 1
-	cmpw     r0, r9
-	bge      lbl_80158254
-	lhz      r0, 2(r31)
-	addi     r8, r4, 1
-	cmpw     r8, r0
-	blt      lbl_8015825C
-
-lbl_80158254:
-	li       r8, 0
-	b        lbl_80158274
-
-lbl_8015825C:
-	mullw    r0, r8, r9
-	lwz      r9, 8(r31)
-	add      r8, r5, r0
-	addi     r0, r8, 1
-	mulli    r0, r0, 0x2c
-	add      r8, r9, r0
-
-lbl_80158274:
-	stw      r3, 0x10(r8)
-
-lbl_80158278:
-	addi     r4, r4, 2
-	addi     r7, r7, 1
-
-lbl_80158280:
-	lhz      r0, 2(r30)
-	cmpw     r7, r0
-	blt      lbl_80157E80
-	addi     r5, r5, 2
-	addi     r6, r6, 1
-
-lbl_80158294:
-	lhz      r0, 0(r30)
-	cmpw     r6, r0
-	blt      lbl_80157E74
-	lwz      r0, 0x44(r1)
-	lwz      r31, 0x3c(r1)
-	lwz      r30, 0x38(r1)
-	lwz      r29, 0x34(r1)
-	mtlr     r0
-	addi     r1, r1, 0x40
-	blr
-	*/
 }
 
 /**
@@ -1342,6 +896,8 @@ void CellPyramid::clear()
 	mZNode.mPrev = 0;
 }
 
+char* CellPyramid::sCellBugName = "none";
+
 /**
  * @note Address: 0x80158390
  * @note Size: 0x190
@@ -1349,7 +905,7 @@ void CellPyramid::clear()
 // void calcExtent__Q24Game11CellPyramidFRQ23Sys6SphereRiR7Rect<i>()
 void CellPyramid::calcExtent(Sys::Sphere& sphere, int& layerIdx, Recti& outRect)
 {
-	f32 exponent = 2.0f * sphere.mRadius * mInverseScale;  // f30
+	f32 exponent = 2.0f * sphere.mRadius * mInverseScale;
 	f32 log2     = (f32)log10(exponent) / (f32)log10(2.0); // change to log base 2
 	if (log2 < 0.0f) {
 		log2 = 0.0f;
@@ -1361,21 +917,22 @@ void CellPyramid::calcExtent(Sys::Sphere& sphere, int& layerIdx, Recti& outRect)
 	}
 
 	u16 layerSize = getLayer(layer)->mLayerSize;
-	f32 scale     = 1.0f / ((f32)layerSize * mScale); // f9
+	f32 mult      = (f32)layerSize * mScale;
 
-	f32 radius = sphere.mRadius;
-	f32 left   = mBounds.x;
-	f32 right  = mBounds.y;
+	f32 xLow = sphere.mPosition.x - sphere.mRadius;
+	f32 xHi  = sphere.mPosition.x + sphere.mRadius;
+	f32 yLow = sphere.mPosition.z - sphere.mRadius;
+	f32 yHi  = sphere.mPosition.z + sphere.mRadius;
 
-	f32 xLow = sphere.mPosition.x - radius;
-	f32 xHi  = sphere.mPosition.x + radius;
-	f32 yLow = sphere.mPosition.z - radius;
-	f32 yHi  = sphere.mPosition.z + radius;
+	f32 left  = mBounds.x;
+	f32 right = mBounds.y;
 
 	f32 xLowDiff = xLow - right;
 	f32 yLowDiff = yLow - left;
 	f32 xHiDiff  = xHi - right;
 	f32 yHiDiff  = yHi - left;
+
+	f32 scale = 1.0f / mult;
 
 	outRect.p1.x = xLowDiff * scale;
 	outRect.p1.y = yLowDiff * scale;
@@ -1383,113 +940,6 @@ void CellPyramid::calcExtent(Sys::Sphere& sphere, int& layerIdx, Recti& outRect)
 	outRect.p2.y = yHiDiff * scale;
 
 	layerIdx = layer;
-	/*
-	.loc_0x0:
-	  stwu      r1, -0x70(r1)
-	  mflr      r0
-	  stw       r0, 0x74(r1)
-	  stfd      f31, 0x60(r1)
-	  psq_st    f31,0x68(r1),0,0
-	  stfd      f30, 0x50(r1)
-	  psq_st    f30,0x58(r1),0,0
-	  stw       r31, 0x4C(r1)
-	  stw       r30, 0x48(r1)
-	  stw       r29, 0x44(r1)
-	  stw       r28, 0x40(r1)
-	  mr        r29, r4
-	  mr        r28, r3
-	  lfs       f2, -0x5D18(r2)
-	  mr        r30, r5
-	  lfs       f1, 0xC(r4)
-	  mr        r31, r6
-	  lfs       f0, 0x38(r3)
-	  fmuls     f2, f2, f1
-	  lfd       f1, -0x5D10(r2)
-	  fmuls     f30, f2, f0
-	  bl        -0x889F8
-	  frsp      f31, f1
-	  fmr       f1, f30
-	  bl        -0x88A04
-	  frsp      f1, f1
-	  lfs       f0, -0x5D38(r2)
-	  fdivs     f1, f1, f31
-	  fcmpo     cr0, f1, f0
-	  bge-      .loc_0x7C
-	  fmr       f1, f0
-
-	.loc_0x7C:
-	  bl        -0x892C4
-	  frsp      f0, f1
-	  lwz       r3, 0x2C(r28)
-	  fctiwz    f0, f0
-	  stfd      f0, 0x8(r1)
-	  lwz       r5, 0xC(r1)
-	  cmpw      r5, r3
-	  blt-      .loc_0xA0
-	  subi      r5, r3, 0x1
-
-	.loc_0xA0:
-	  mulli     r3, r5, 0x38
-	  lis       r0, 0x4330
-	  lwz       r4, 0x30(r28)
-	  stw       r0, 0x10(r1)
-	  addi      r0, r3, 0x4
-	  lfd       f2, -0x5D28(r2)
-	  lhzx      r0, r4, r0
-	  lfs       f1, 0x34(r28)
-	  stw       r0, 0x14(r1)
-	  lfs       f3, -0x5D08(r2)
-	  lfd       f0, 0x10(r1)
-	  lfs       f5, 0xC(r29)
-	  fsubs     f2, f0, f2
-	  lfs       f4, 0x0(r29)
-	  lfs       f6, 0x8(r29)
-	  fsubs     f0, f4, f5
-	  lfs       f8, 0x40(r28)
-	  fmuls     f1, f2, f1
-	  fadds     f2, f4, f5
-	  lfs       f7, 0x3C(r28)
-	  fsubs     f4, f6, f5
-	  fdivs     f9, f3, f1
-	  fsubs     f1, f0, f8
-	  fsubs     f3, f4, f7
-	  fadds     f0, f6, f5
-	  fmuls     f1, f1, f9
-	  fsubs     f4, f2, f8
-	  fmuls     f2, f3, f9
-	  fctiwz    f3, f1
-	  fsubs     f0, f0, f7
-	  fmuls     f1, f4, f9
-	  fctiwz    f2, f2
-	  stfd      f3, 0x18(r1)
-	  fmuls     f0, f0, f9
-	  fctiwz    f1, f1
-	  lwz       r0, 0x1C(r1)
-	  stfd      f2, 0x20(r1)
-	  fctiwz    f0, f0
-	  stfd      f1, 0x28(r1)
-	  lwz       r3, 0x24(r1)
-	  stw       r0, 0x0(r31)
-	  lwz       r0, 0x2C(r1)
-	  stw       r3, 0x4(r31)
-	  stfd      f0, 0x30(r1)
-	  stw       r0, 0x8(r31)
-	  lwz       r0, 0x34(r1)
-	  stw       r0, 0xC(r31)
-	  stw       r5, 0x0(r30)
-	  psq_l     f31,0x68(r1),0,0
-	  lfd       f31, 0x60(r1)
-	  psq_l     f30,0x58(r1),0,0
-	  lfd       f30, 0x50(r1)
-	  lwz       r31, 0x4C(r1)
-	  lwz       r30, 0x48(r1)
-	  lwz       r29, 0x44(r1)
-	  lwz       r0, 0x74(r1)
-	  lwz       r28, 0x40(r1)
-	  mtlr      r0
-	  addi      r1, r1, 0x70
-	  blr
-	*/
 }
 
 /**
@@ -1508,8 +958,6 @@ void CellPyramid::entry(CellObject* object, Sys::Sphere& sphere)
 	Cell::sCurrCellMgr = nullptr;
 }
 
-// TODO: Finish this. It's pretty much one big ol' usage of inlined functions.
-// I know that SysShape::Model::entry(Sys::Sphere&) exists, among others...
 /**
  * @note Address: 0x80158554
  * @note Size: 0x4B8
@@ -1518,114 +966,57 @@ void CellPyramid::entry(CellObject* object, Sys::Sphere& sphere, int& layerIndex
 {
 	Cell::sCurrCellMgr = this;
 
-	f32 sphereRadiusLog = log10(sphere.mRadius * 2.0f * mInverseScale);
-	f32 log2            = log10(2.0f);
-	f32 layerIndexFloat = (sphereRadiusLog / log2);
+	calcExtent(sphere, layerIndex, boundingRect);
 
-	// Ensure the layer is non-negative
-	if (layerIndexFloat < 0.0f) {
-		layerIndexFloat = 0.0f;
-	}
-
-	layerIndex = (int)ceil(MAX(layerIndexFloat, 0.0f));
-
-	// Ensure that layerIndex is within bounds
-	if (mLayerCount <= layerIndex) {
-		layerIndex = mLayerCount - 1;
-	}
-
-	f32 sphereRadius       = sphere.mRadius;
-	f32 sphereX            = sphere.mPosition.x;
-	f32 sphereZ            = sphere.mPosition.z;
-	f32 rightBoundary      = mBounds.y;
-	f32 leftBoundary       = mBounds.x;
-	f32 inverseScaleFactor = 1.0f / ((mLayers[layerIndex].mLayerSize) * mScale);
-
-	// Calculate the bounding rectangle
-	boundingRect.p1.x = (int)(((sphereX - sphereRadius) - rightBoundary) * inverseScaleFactor);
-	boundingRect.p1.y = (int)(((sphereZ - sphereRadius) - leftBoundary) * inverseScaleFactor);
-	boundingRect.p2.x = (int)(((sphereX + sphereRadius) - rightBoundary) * inverseScaleFactor);
-	boundingRect.p2.y = (int)(((sphereZ + sphereRadius) - leftBoundary) * inverseScaleFactor);
-
-	// Update the layerIndex
-	layerIndex = layerIndex;
-
-	// Check if layerIndex is out of bounds
-	if ((layerIndex < 0) || (mLayerCount <= layerIndex)) {
+	if ((layerIndex < 0) || (layerIndex >= mLayerCount)) {
 		JUT_PANICLINE(1206, "illegal layerLevel %d : out of bounds 0～%d\n", layerIndex, mLayerCount);
 		return;
 	}
 
-	int objectLayerIndex    = 0;
-	bool isPikiOrNavi       = false;
-	CellLayer* currentLayer = &mLayers[layerIndex];
-	bool isPiki             = object->isPiki();
-
+	u8 pikiOrNavi    = 0;
+	CellLayer* layer = &mLayers[layerIndex];
+	bool isPiki      = object->isPiki();
 	if ((isPiki != false) || (isPiki = object->isNavi(), isPiki != false)) {
-		objectLayerIndex = 1;
-		isPikiOrNavi     = true;
+		pikiOrNavi = 1;
 	}
-
-	layerIndex = objectLayerIndex;
+	bool isPikiOrNavi = pikiOrNavi != 0;
 
 	for (int i = 0; i < 4; i++) {
-		Cell* cell = object->mCellLegs->mCell;
-
+		Cell* cell = object->mCellLegs[i].mCell;
 		if (cell) {
-			cell->exit(object->mCellLegs, isPikiOrNavi);
-
-			if (cell->mLeg == object->mCellLegs) {
-				cell->mLeg = object->mCellLegs->mNext;
-
-				if (cell->mLeg) {
-					cell->mLeg->mPrev = nullptr;
-				}
-			}
-
-			if (isPikiOrNavi && cell->mLocalPikiNaviCount != 0) {
-				cell->mLocalPikiNaviCount--;
-
-				for (Cell* iCell = cell->mHeadCell; iCell != nullptr; iCell = iCell->mHeadCell) {
-					iCell->mTotalPikiNaviCount--;
-				}
-			}
-
-			cell->mTotalObjectCount--;
-			for (Cell* iCell = cell->mHeadCell; iCell != nullptr; iCell = iCell->mHeadCell) {
-				iCell->mTotalObjectCount--;
-			}
-
-			CellLeg* leg = object->mCellLegs->mPrev;
-
-			if (leg != nullptr) {
-				leg->mNext = object->mCellLegs->mNext;
-			}
-
-			leg = object->mCellLegs->mNext;
-
-			if (leg) {
-				leg->mPrev = object->mCellLegs->mPrev;
-			}
-
-			object->mCellLegs->mPrev = nullptr;
-			object->mCellLegs->mNext = nullptr;
-
-			if (cell->mLeg == nullptr && Cell::sCurrCellMgr != nullptr) {
-				if (cell->mPrevCell) {
-					cell->mPrevCell->mNextCell = cell->mNextCell;
-
-					if (cell->mNextCell) {
-						cell->mNextCell->mPrevCell = cell->mPrevCell;
-					}
-				}
-
-				cell->mPrevCell = nullptr;
-				cell->mNextCell = nullptr;
-			}
-
-			object->mCellLegs->mCell = nullptr;
+			cell->exit(&object->mCellLegs[i], isPikiOrNavi);
+			object->mCellLegs[i].mCell = nullptr;
 		}
 	}
+
+	int legIndex = 0;
+	if (((boundingRect.p2.x - boundingRect.p1.x) * (boundingRect.p2.y - boundingRect.p1.y)) > 10) {
+		JUT_PANICLINE(1405, "Cell Inf-Loop かもしれない\n");
+		return;
+	}
+
+	for (int x = boundingRect.p1.x; x <= boundingRect.p2.x; x++) {
+		for (int y = boundingRect.p1.y; y <= boundingRect.p2.y; y++) {
+			Cell* cell = (*layer)(x, y);
+			if (cell) {
+				if (legIndex >= 4) {
+					Cell::sCurrCellMgr = nullptr;
+					return;
+				}
+
+				cell->entry(&object->mCellLegs[legIndex], isPikiOrNavi);
+
+				bool legCheck = cell->mLeg->findLeg(&object->mCellLegs[legIndex]);
+				if (!legCheck) {
+					JUT_PANICLINE(1439, "leg entry failed !!!!!!!!!!\n");
+					return;
+				}
+			}
+			legIndex++;
+		}
+	}
+
+	Cell::sCurrCellMgr = nullptr;
 }
 
 /**
@@ -1637,11 +1028,7 @@ void CellPyramid::create(BoundBox2d& box, f32 scale)
 	mFreeMemory = JKRHeap::sCurrentHeap->getFreeSize();
 
 	mBounds.set(box.mMin.y, box.mMin.x);
-	// setLeftRight(box.mMin.x, box.mMin.y);
-	// mLeft         = box.mMin.x;
-	// mRight        = box.mMax.x;
 
-	// Calculate dimensions in pixels
 	f32 absDiffX    = absF(box.mMax.x - box.mMin.x);
 	f32 absDiffY    = absF(box.mMax.y - box.mMin.y);
 	mScale          = scale;
@@ -1657,9 +1044,10 @@ void CellPyramid::create(BoundBox2d& box, f32 scale)
 		pixelHeight   = (f32)ceil(absDiffY * mInverseScale);
 	}
 
-	int maxDimension = pixelWidth > pixelHeight ? pixelWidth : pixelHeight;
+	int maxDimension = MAX(pixelWidth, pixelHeight);
 
-	int layerCount = (f32)ceil((f32)log10((f32)maxDimension) / (f32)log10(2.0f));
+	f32 log2       = (f32)log10(2.0f);
+	int layerCount = (f32)ceil((f32)log10((f32)maxDimension) / log2);
 	pow(2.0, (f64)layerCount);
 
 	mLayerCount       = layerCount + 1;
@@ -1672,210 +1060,6 @@ void CellPyramid::create(BoundBox2d& box, f32 scale)
 	}
 
 	mFreeMemory = mFreeMemory - JKRHeap::sCurrentHeap->getFreeSize();
-	/*
-	.loc_0x0:
-	  stwu      r1, -0x70(r1)
-	  mflr      r0
-	  stw       r0, 0x74(r1)
-	  stfd      f31, 0x60(r1)
-	  psq_st    f31,0x68(r1),0,0
-	  stfd      f30, 0x50(r1)
-	  psq_st    f30,0x58(r1),0,0
-	  stfd      f29, 0x40(r1)
-	  psq_st    f29,0x48(r1),0,0
-	  stmw      r27, 0x2C(r1)
-	  fmr       f31, f1
-	  mr        r31, r3
-	  lwz       r3, -0x77D4(r13)
-	  mr        r27, r4
-	  bl        -0x135290
-	  lfs       f0, -0x5D08(r2)
-	  stw       r3, 0x28(r31)
-	  fdivs     f0, f0, f31
-	  lfs       f2, 0x0(r27)
-	  lfs       f1, 0x4(r27)
-	  stfs      f1, 0x3C(r31)
-	  stfs      f2, 0x40(r31)
-	  lfs       f4, 0x8(r27)
-	  lfs       f3, 0x0(r27)
-	  lfs       f2, 0xC(r27)
-	  lfs       f1, 0x4(r27)
-	  fsubs     f3, f4, f3
-	  stfs      f31, 0x34(r31)
-	  fsubs     f1, f2, f1
-	  fabs      f2, f3
-	  stfs      f0, 0x38(r31)
-	  fabs      f1, f1
-	  frsp      f30, f2
-	  lfs       f0, 0x38(r31)
-	  frsp      f29, f1
-	  fmuls     f1, f30, f0
-	  bl        -0x89954
-	  frsp      f2, f1
-	  lfs       f0, 0x38(r31)
-	  fmuls     f1, f29, f0
-	  fctiwz    f0, f2
-	  stfd      f0, 0x8(r1)
-	  lwz       r28, 0xC(r1)
-	  bl        -0x89970
-	  frsp      f0, f1
-	  cmpwi     r28, 0xC8
-	  fctiwz    f0, f0
-	  stfd      f0, 0x10(r1)
-	  lwz       r27, 0x14(r1)
-	  bgt-      .loc_0xD0
-	  cmpwi     r27, 0xC8
-	  ble-      .loc_0x120
-
-	.loc_0xD0:
-	  lfs       f1, -0x5D04(r2)
-	  lfs       f0, -0x5D08(r2)
-	  fmuls     f31, f31, f1
-	  fdivs     f0, f0, f31
-	  stfs      f31, 0x34(r31)
-	  stfs      f0, 0x38(r31)
-	  lfs       f0, 0x38(r31)
-	  fmuls     f1, f30, f0
-	  bl        -0x899B4
-	  frsp      f2, f1
-	  lfs       f0, 0x38(r31)
-	  fmuls     f1, f29, f0
-	  fctiwz    f0, f2
-	  stfd      f0, 0x10(r1)
-	  lwz       r28, 0x14(r1)
-	  bl        -0x899D0
-	  frsp      f0, f1
-	  fctiwz    f0, f0
-	  stfd      f0, 0x8(r1)
-	  lwz       r27, 0xC(r1)
-
-	.loc_0x120:
-	  cmpw      r28, r27
-	  mr        r30, r27
-	  ble-      .loc_0x130
-	  mr        r30, r28
-
-	.loc_0x130:
-	  lfd       f1, -0x5D10(r2)
-	  bl        -0x89154
-	  xoris     r3, r30, 0x8000
-	  lis       r0, 0x4330
-	  stw       r3, 0x14(r1)
-	  frsp      f29, f1
-	  lfd       f1, -0x5D00(r2)
-	  stw       r0, 0x10(r1)
-	  lfd       f0, 0x10(r1)
-	  fsubs     f1, f0, f1
-	  bl        -0x89178
-	  frsp      f0, f1
-	  fdivs     f1, f0, f29
-	  bl        -0x89A28
-	  frsp      f0, f1
-	  lis       r0, 0x4330
-	  stw       r0, 0x18(r1)
-	  lfd       f2, -0x5D00(r2)
-	  fctiwz    f0, f0
-	  lfd       f1, -0x5D10(r2)
-	  stfd      f0, 0x8(r1)
-	  lwz       r29, 0xC(r1)
-	  xoris     r0, r29, 0x8000
-	  stw       r0, 0x1C(r1)
-	  lfd       f0, 0x18(r1)
-	  fsub      f2, f0, f2
-	  bl        -0x89198
-	  addi      r0, r29, 0x1
-	  stw       r0, 0x2C(r31)
-	  lwz       r30, 0x2C(r31)
-	  mulli     r3, r30, 0x38
-	  addi      r3, r3, 0x10
-	  bl        -0x134C10
-	  lis       r4, 0x8016
-	  mr        r7, r30
-	  subi      r4, r4, 0x7308
-	  li        r5, 0
-	  li        r6, 0x38
-	  bl        -0x971E4
-	  stw       r3, 0x30(r31)
-	  li        r3, 0x1
-	  li        r0, 0
-	  lwz       r29, 0x30(r31)
-	  sth       r28, 0x0(r29)
-	  sth       r27, 0x2(r29)
-	  sth       r3, 0x4(r29)
-	  sth       r0, 0x6(r29)
-	  lhz       r3, 0x0(r29)
-	  lhz       r0, 0x2(r29)
-	  mullw     r30, r3, r0
-	  mulli     r3, r30, 0x2C
-	  addi      r3, r3, 0x10
-	  bl        -0x134C60
-	  lis       r4, 0x8015
-	  mr        r7, r30
-	  addi      r4, r4, 0x6740
-	  li        r5, 0
-	  li        r6, 0x2C
-	  bl        -0x97234
-	  stw       r3, 0x8(r29)
-	  li        r5, 0
-	  mr        r6, r5
-	  stw       r5, 0x2C(r29)
-	  mr        r7, r5
-	  stw       r5, 0x30(r29)
-	  b         .loc_0x260
-
-	.loc_0x238:
-	  lwz       r3, 0x8(r29)
-	  addi      r0, r7, 0x28
-	  addi      r6, r6, 0x1
-	  add       r3, r3, r7
-	  addi      r7, r7, 0x2C
-	  stw       r5, 0x1C(r3)
-	  sth       r5, 0x18(r3)
-	  lhz       r4, 0x6(r29)
-	  lwz       r3, 0x8(r29)
-	  sthx      r4, r3, r0
-
-	.loc_0x260:
-	  lhz       r3, 0x0(r29)
-	  lhz       r0, 0x2(r29)
-	  mullw     r0, r3, r0
-	  cmpw      r6, r0
-	  blt+      .loc_0x238
-	  li        r27, 0x1
-	  li        r29, 0x38
-	  b         .loc_0x2A0
-
-	.loc_0x280:
-	  subi      r0, r27, 0x1
-	  lwz       r4, 0x30(r31)
-	  mulli     r0, r0, 0x38
-	  add       r3, r4, r29
-	  add       r4, r4, r0
-	  bl        -0xF5C
-	  addi      r29, r29, 0x38
-	  addi      r27, r27, 0x1
-
-	.loc_0x2A0:
-	  lwz       r0, 0x2C(r31)
-	  cmpw      r27, r0
-	  blt+      .loc_0x280
-	  lwz       r3, -0x77D4(r13)
-	  bl        -0x135508
-	  lwz       r0, 0x28(r31)
-	  sub       r0, r0, r3
-	  stw       r0, 0x28(r31)
-	  psq_l     f31,0x68(r1),0,0
-	  lfd       f31, 0x60(r1)
-	  psq_l     f30,0x58(r1),0,0
-	  lfd       f30, 0x50(r1)
-	  psq_l     f29,0x48(r1),0,0
-	  lfd       f29, 0x40(r1)
-	  lmw       r27, 0x2C(r1)
-	  lwz       r0, 0x74(r1)
-	  mtlr      r0
-	  addi      r1, r1, 0x70
-	  blr
-	*/
 }
 
 /**
@@ -2074,4 +1258,5 @@ void Cell::resolveCollision_3()
 		}
 	}
 }
+
 } // namespace Game


### PR DESCRIPTION
Highlights:
  - fully matches CellLayer::pileup (97.46% to100%)
  - fully matches CellPyramid::calcExtent (98.90% to 100%)
  - rewrites CellPyramid::entry (58.96% to 98.81%)
  - improves CellPyramid::create (93.34% to 93.39%) instruction identical with regswaps only
  - fixes static data: sOptResolveColl init (1 to 2, per original .sdata), .sdata 40% to 100%, .rodata 77.78% to 100%, .sdata2 93.33% to 100%
  - removes obsolete embedded asm blocks and stale WIP comments

Progress:
  - unit fuzzy match: 94.89% to 99.44%
  - functions matched: 34/38 to 36/38
  - all data sections now 100%

Verification:
  - full Ninja build passes
  - no other unit's match state changed
  - runtime verified: completed Day 1 on an Equivalent build with this TU's compiled code linked in, no crashes, asserts, or visible misbehavior