### PR TITLE
match bulborb attack logic and itemUjamushi model setup

### DIFF
--- a/include/Game/EnemyBase.h
+++ b/include/Game/EnemyBase.h
@@ -475,6 +475,17 @@ struct EnemyBase : public Creature, public SysShape::MotionListener, virtual pub
 		return result;
 	}
 
+	// @fabricated signature, but required to match - reads mTargetCreature itself instead of taking it as a parameter
+	inline bool isTargetAttackable(f32 angleDiff, f32 attackDist, f32 attackAngle)
+	{
+		bool result      = false;
+		Creature* target = mTargetCreature;
+		if (isRadiusWithin(getSqrTargetSeparation(target), attackDist) && (isAngleWithin(angleDiff, attackAngle))) {
+			result = true;
+		}
+		return result;
+	}
+
 	inline bool isTargetAttackable(Creature* target, f32 attackDist, f32 attackAngle)
 	{
 		f32 angleDiff = getAngDist(target);

--- a/src/plugProjectKandoU/itemUjamushi.cpp
+++ b/src/plugProjectKandoU/itemUjamushi.cpp
@@ -2425,7 +2425,7 @@ Mgr::Mgr()
 	setModelSize(2);
 	loadArchive("arc.szs");
 	loadBmd("ujamushi_poly.bmd", 0, J3DMODEL_CreateNewDL);
-	loadBmd("ujamushi_bill.bmd", 1, J3DMODEL_Unk26 | J3DMODEL_CreateNewDL);
+	loadBmd("ujamushi_bill.bmd", 1, J3DMODEL_Unk30 | J3DMODEL_CreateNewDL);
 	_308                   = 0;
 	_304                   = 0;
 	_30C                   = 0.0f;

--- a/src/plugProjectYamashitaU/chappyState.cpp
+++ b/src/plugProjectYamashitaU/chappyState.cpp
@@ -48,8 +48,7 @@ void StateCautionBase::cautionProc(EnemyBase* enemy)
 	bool doAlert;
 	switch (enemy->getEnemyTypeID()) {
 	case EnemyTypeID::EnemyID_BlueChappy: {
-		f32 wakeRadius = CG_PROPERPARMS(OBJ(enemy)).mBulborbWakeRadius.mValue;
-		doAlert        = EnemyFunc::isPikminOrNaviInRange(enemy, wakeRadius);
+		doAlert = EnemyFunc::isPikminOrNaviInRange(enemy, CG_PROPERPARMS(OBJ(enemy)).mBulborbWakeRadius.mValue);
 
 		if (!doAlert) {
 			doAlert = enemy->mHealth < CG_GENERALPARMS(enemy).mLifeBeforeAlert.mValue;
@@ -58,8 +57,7 @@ void StateCautionBase::cautionProc(EnemyBase* enemy)
 	}
 
 	default: {
-		f32 wakeRadius = CG_GENERALPARMS(enemy).mPrivateRadius.mValue;
-		doAlert        = EnemyFunc::isPikminOrNaviInRange(enemy, wakeRadius);
+		doAlert = EnemyFunc::isPikminOrNaviInRange(enemy, CG_GENERALPARMS(enemy).mPrivateRadius.mValue);
 
 		if (!doAlert) {
 			doAlert = enemy->mHealth < CG_GENERALPARMS(enemy).mLifeBeforeAlert.mValue;
@@ -1939,8 +1937,7 @@ void StateAttack::transitState(EnemyBase* enemy)
 		enemy->mTargetCreature = target;
 
 		f32 angle = enemy->getAngDist(enemy->mTargetCreature);
-		if (enemy->isTargetAttackable(enemy->mTargetCreature, angle, CG_GENERALPARMS(enemy).mMaxAttackRange(),
-		                              CG_GENERALPARMS(enemy).mMaxAttackAngle())) {
+		if (enemy->isTargetAttackable(angle, CG_GENERALPARMS(enemy).mMaxAttackRange(), CG_GENERALPARMS(enemy).mMaxAttackAngle())) {
 			transit(enemy, CHAPPY_Attack, nullptr);
 			return;
 		}

--- a/src/plugProjectYamashitaU/kochappyState.cpp
+++ b/src/plugProjectYamashitaU/kochappyState.cpp
@@ -113,10 +113,13 @@ void StateWait::exec(EnemyBase* enemy)
 				enemy->getJAIObject()->startSound(PSSE_EN_KOCHAPPY_NOTICE, 0);
 				break;
 			case KEYEVENT_END:
-				Parms* parms = CG_PARMS(enemy);
-				f32 angLimit = parms->mProperParms.mRotationEndAngle();
-				f32 angDist  = enemy->turnToTarget(enemy->mTargetCreature, CG_GENERALPARMS(enemy).mTurnSpeed(),
-				                                   CG_GENERALPARMS(enemy).mMaxTurnAngle()); // this is wrong?
+				Parms* parms     = CG_PARMS(enemy);
+				f32 angLimit     = parms->mProperParms.mRotationEndAngle();
+				f32 maxTurnAngle = CG_GENERALPARMS(enemy).mMaxTurnAngle();
+				f32 turnSpeed    = CG_GENERALPARMS(enemy).mTurnSpeed();
+				f32 angDist      = enemy->getAngDist(enemy->mTargetCreature);
+				f32 angle        = clamp(angDist * turnSpeed, TORADIANS(maxTurnAngle));
+				enemy->updateFaceDir(roundAng(angle + enemy->getFaceDir()));
 				if (isAngleWithin(angDist, angLimit)) {
 					transit(enemy, KOCHAPPY_Walk, nullptr);
 				} else {
@@ -443,8 +446,7 @@ void StateTurn::exec(EnemyBase* enemy)
 		if (target) {
 			enemy->mTargetCreature = target;
 			f32 angle              = enemy->getAngDist(enemy->mTargetCreature);
-			if (enemy->isTargetAttackable(enemy->mTargetCreature, angle, CG_GENERALPARMS(enemy).mMaxAttackRange,
-			                              CG_GENERALPARMS(enemy).mMaxAttackAngle)) {
+			if (enemy->isTargetAttackable(angle, CG_GENERALPARMS(enemy).mMaxAttackRange, CG_GENERALPARMS(enemy).mMaxAttackAngle)) {
 				mNextState = KOCHAPPY_Attack;
 				enemy->finishMotion();
 				OBJ(enemy)->setAnimationSpeed(60.0f);
@@ -454,8 +456,12 @@ void StateTurn::exec(EnemyBase* enemy)
 					mNextState = KOCHAPPY_TurnToHome;
 					enemy->finishMotion();
 				} else {
-					if (enemy->turnToTarget(enemy->mTargetCreature, CG_GENERALPARMS(enemy).mTurnSpeed(),
-					                        CG_GENERALPARMS(enemy).mMaxTurnAngle(), CG_PROPERPARMS(enemy).mRotationEndAngle())) {
+					f32 maxTurnAngle = CG_GENERALPARMS(enemy).mMaxTurnAngle();
+					f32 turnSpeed    = CG_GENERALPARMS(enemy).mTurnSpeed();
+					f32 angDist      = enemy->getAngDist(enemy->mTargetCreature);
+					f32 angle        = clamp(angDist * turnSpeed, TORADIANS(maxTurnAngle));
+					enemy->updateFaceDir(roundAng(angle + enemy->getFaceDir()));
+					if (isAngleWithin(angDist, CG_PROPERPARMS(enemy).mRotationEndAngle())) {
 						mNextState = KOCHAPPY_Walk;
 						enemy->finishMotion();
 						OBJ(enemy)->setAnimationSpeed(60.0f);
@@ -1638,8 +1644,7 @@ void StateAttack::exec(EnemyBase* enemy)
 			if (target) {
 				enemy->mTargetCreature = target;
 				f32 angle              = enemy->getAngDist(enemy->mTargetCreature);
-				if (enemy->isTargetAttackable(enemy->mTargetCreature, angle, CG_GENERALPARMS(enemy).mMaxAttackRange(),
-				                              CG_GENERALPARMS(enemy).mMaxAttackAngle())) {
+				if (enemy->isTargetAttackable(angle, CG_GENERALPARMS(enemy).mMaxAttackRange(), CG_GENERALPARMS(enemy).mMaxAttackAngle())) {
 					transit(enemy, KOCHAPPY_Attack, nullptr);
 				} else {
 					transit(enemy, KOCHAPPY_Turn, nullptr);


### PR DESCRIPTION
## Summary

- Match ChappyBase::StateAttack::transitState
- Match KochappyBase::StateAttack::exec
- Improve Kochappy wait/turn (StateWait::exec from ~90.3% to ~97.6%)
- Match the ItemUjamushi::Mgr constructor by correcting its billboard model flag

## Testing

- ninja all_source progress


